### PR TITLE
Migration from ADE to Yocto SDK

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -157,7 +157,7 @@ include conf/include/drop-toolchain-from-sdk.inc
 # We default to ipk:
 #PACKAGE_CLASSES ?= "package_ipk"
 
-# SDK/ADT target architecture
+# SDK target architecture
 #
 # Set to one of the mingw32 SDKMACHINEs to target Windows rather than Linux.
 # Warning: if you choose to add packages to TOOLCHAIN_HOST_TASK and target
@@ -169,31 +169,28 @@ include conf/include/drop-toolchain-from-sdk.inc
 # Uncomment to make populate_sdk write a tar file rather than a .sh installer
 #SDK_PACKAGING_FUNC = ""
 
-# By default, only include the target sysroot in the SDK/ADE, not host tools.
+# By default, only include the target sysroot in the SDK, not host tools.
 # Comment this line to change that. This packagegroup includes host tools like
-# autoconf, automake, etc. See the aforementioned warning about use of Windows
-# SDKMACHINE while setting TOOLCHAIN_HOST_TASK, if you're building a Windows
-# SDK/ADE.
+# autoconf, automake, etc.
 TOOLCHAIN_HOST_REMOVE ??= "nativesdk-packagegroup-sdk-host"
 TOOLCHAIN_HOST_TASK:remove = "${TOOLCHAIN_HOST_REMOVE}"
 
-# TOOLCHAIN_HOST_TASK is used to add host packages to the ADE/SDK, for
+# TOOLCHAIN_HOST_TASK is used to add host packages to the SDK, for
 # example, to add bash:
 #TOOLCHAIN_HOST_TASK_EXTRA += " nativesdk-bash"
 
-# TOOLCHAIN_TARGET_TASK is used to add target packages to the ADE/SDK, for
+# TOOLCHAIN_TARGET_TASK is used to add target packages to the SDK, for
 # example, to add libncurses:
 #TOOLCHAIN_TARGET_TASK_EXTRA += " ncurses-libncurses"
 
-# Uncomment to set a site name (shown in CodeBench) for the ADE
-# Default: ADE for ${ADE_IDENTIFIER}
-#ADE_SITENAME ?= "My Company's ADE for ${ADE_IDENTIFIER}"
+# Uncomment to set a title for the SDK
+# Default: SDK for ${SDK_IDENTIFIER}
+#SDK_TITLE ?= "My Company's SDK for ${SDK_IDENTIFIER}"
 
-# Uncomment to alter the identifier for the ADE. This mechanism is used to
-# support installation of multiple ADEs side-by-side. By default, every ADE
-# build gets its own identifier, so is self-contained already.
-# Default: ${SDKMACHINE}-${IMAGE_BASENAME}-${MACHINE}-${ADE_VERSION}
-#ADE_IDENTIFIER ?= "${SDKMACHINE}-${IMAGE_BASENAME}-${MACHINE}-${ADE_VERSION}.customized"
+# Uncomment to alter the identifier for the SDK. This mechanism is used to
+# isolate the SDK on disk, as well as the installers.
+# Default: ${SDKMACHINE}-${IMAGE_BASENAME}-${MACHINE}-${SDK_VERSION}
+#SDK_IDENTIFIER ?= "${SDKMACHINE}-${IMAGE_BASENAME}-${MACHINE}-${SDK_VERSION}.customized"
 
 # The following is a list of additional classes to use when building which
 # enable extra features. Some available options which can be included in this variable

--- a/meta-sokol-flex-common/classes/codebench-environment-setup-d-hack.bbclass
+++ b/meta-sokol-flex-common/classes/codebench-environment-setup-d-hack.bbclass
@@ -1,0 +1,25 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# SPDX-License-Identifier: MIT
+# ---------------------------------------------------------------------------------------------------------------------
+
+# Work around lack of support for environment-setup.d in CodeBench
+SDK_PACKAGING_COMMAND:prepend:sdk-codebench-metadata = "merge_environment_setup_d; add_no_sysroot_suffix;"
+
+merge_environment_setup_d() {
+    for setup_d in "${SDK_OUTPUT}${SDKPATH}/sysroots/"*/environment-setup.d; do
+        if [ -d "$setup_d" ]; then
+            for script in "${SDK_OUTPUT}${SDKPATH}/environment-setup-"*; do
+                find "$setup_d" -type f -print0 | xargs -0 cat >>"$script"
+            done
+            rm -rf "$setup_d"
+        fi
+    done
+}
+
+add_no_sysroot_suffix() {
+    # Codebench expects the --no-sysroot-suffix entries to be in the main
+    # variables, not the appended ones from external.sh
+    for script in "${SDK_OUTPUT}${SDKPATH}/environment-setup-"*; do
+        sed -i -e "/no-sysroot-suffix/d; /\(CC\|CXX\|CPP\|KCFLAGS\)/s/--sysroot=/--no-sysroot-suffix --sysroot=/g" "$script"
+    done
+}

--- a/meta-sokol-flex-common/classes/sdk_codebench_metadata.bbclass
+++ b/meta-sokol-flex-common/classes/sdk_codebench_metadata.bbclass
@@ -20,9 +20,9 @@ CODEBENCH_SDK_VARS += "\
     DISTRO \
     DISTRO_NAME \
     DISTRO_VERSION \
-    ADE_IDENTIFIER \
-    ADE_SITENAME \
-    ADE_VERSION \
+    SDK_IDENTIFIER \
+    SDK_TITLE \
+    SDK_VERSION \
     gdb_serverpath=${bindir}/gdbserver \
 "
 CODEBENCH_SDK_VARS:append:tcmode-external-sourcery = "\

--- a/meta-sokol-flex-common/classes/sdk_codebench_metadata.bbclass
+++ b/meta-sokol-flex-common/classes/sdk_codebench_metadata.bbclass
@@ -1,0 +1,244 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# SPDX-License-Identifier: MIT
+# ---------------------------------------------------------------------------------------------------------------------
+
+# Write additiional metadata for CodeBench to the SDK when codebench-metadata is
+# in SDKIMAGE_FEATURES.
+
+inherit sdk_extra_vars codebench-environment-setup-d-hack
+
+OVERRIDES =. "${@bb.utils.contains('SDKIMAGE_FEATURES', 'codebench-metadata', 'sdk-codebench-metadata:', '', d)}"
+
+SDK_POSTPROCESS_COMMAND:prepend:sdk-codebench-metadata = "adjust_sdk_script_codebench; write_codebench_metadata;"
+
+TOOLCHAIN_HOST_TASK:append:sdk-codebench-metadata = " ${@bb.utils.contains('BBFILE_COLLECTIONS', 'sokol-flex-support', 'nativesdk-relocate-makefile', '', d)}"
+TOOLCHAIN_TARGET_TASK:append:sdk-codebench-metadata = " ${@bb.utils.contains('BBFILE_COLLECTIONS', 'sokol-flex-support', 'codebench-makefile', '', d)}"
+
+SOURCERY_VERSION ?= ""
+CODEBENCH_SDK_VARS += "\
+    MACHINE \
+    DISTRO \
+    DISTRO_NAME \
+    DISTRO_VERSION \
+    ADE_IDENTIFIER \
+    ADE_SITENAME \
+    ADE_VERSION \
+    gdb_serverpath=${bindir}/gdbserver \
+"
+CODEBENCH_SDK_VARS:append:tcmode-external-sourcery = "\
+    SOURCERY_VERSION \
+    TOOLCHAIN_VERSION=${@d.getVar('SOURCERY_VERSION').split('-', 1)[0]} \
+"
+EXTRA_SDK_VARS:append:sdk-codebench-metadata = " ${CODEBENCH_SDK_VARS}"
+
+
+CB_MBS_OPTIONS ?= ""
+CB_MBS_OPTIONS_FEATURES_MAP ?= ""
+CB_MBS_OPTIONS_FLAGS_MAP ?= ""
+CB_MBS_OPTIONS_FLAGS_VALUE_MAP ?= ""
+
+CB_MBS_OPTIONS_CC_FLAGS_MAP ?= ""
+CB_MBS_OPTIONS_CC_FLAGS_MAP[-g] = "compiler*option.debugging.level=debugging.level.default"
+CB_MBS_OPTIONS_CC_FLAGS_MAP[-g0] = "compiler*option.debugging.level=debugging.level.none"
+CB_MBS_OPTIONS_CC_FLAGS_MAP[-g1] = "compiler*option.debugging.level=debugging.level.minimal"
+CB_MBS_OPTIONS_CC_FLAGS_MAP[-g3] = "compiler*option.debugging.level=debugging.level.max"
+CB_MBS_OPTIONS_CC_FLAGS_MAP[-O0] = "compiler*option.optimization.level=optimization.level.none"
+CB_MBS_OPTIONS_CC_FLAGS_MAP[-O1] = "compiler*option.optimization.level=optimization.level.optimize"
+CB_MBS_OPTIONS_CC_FLAGS_MAP[-O2] = "compiler*option.optimization.level=optimization.level.more"
+CB_MBS_OPTIONS_CC_FLAGS_MAP[-O3] = "compiler*option.optimization.level=optimization.level.most"
+CB_MBS_OPTIONS_CC_FLAGS_MAP[-Os] = "compiler*option.optimization.level=optimization.level.size"
+CB_MBS_OPTIONS_CC_FLAGS_MAP[-Og] = "compiler*option.optimization.level=optimization.level.debug"
+
+CB_MBS_IGNORED_EXTRA_FLAGS ?= ""
+CB_MBS_IGNORED_EXTRA_FLAGS += "${@'-mcpu=* -march=* -mtune=*' if d.getVarFlag('CB_MBS_OPTIONS', 'general.cpu', expand=True) else ''}"
+CB_MBS_IGNORED_EXTRA_FLAGS += "${@'-mfpu=*' if d.getVarFlag('CB_MBS_OPTIONS', 'general.fpu', expand=True) else ''}"
+CB_MBS_IGNORED_EXTRA_FLAGS[doc] = "Arguments we don't want to include in the extra options, as they're already handled elsewhere."
+
+CB_MBS_IGNORED_FLAGS ?= ""
+CB_MBS_IGNORED_FLAGS[doc] = "General flag arguments we don't want to include."
+
+
+adjust_sdk_script_codebench () {
+    # Determine the script's location relative to itself rather than hardcoding it
+    script=${SDK_OUTPUT}/${SDKPATH}/environment-setup-${REAL_MULTIMACH_TARGET_SYS}
+    cat >"${script}.new" <<END
+if [ -n "\$BASH_SOURCE" ] || [ -n "\$ZSH_NAME" ]; then
+    if [ -n "\$BASH_SOURCE" ]; then
+        scriptdir="\$(cd "\$(dirname "\$BASH_SOURCE")" && pwd)"
+    elif [ -n "\$ZSH_NAME" ]; then
+        scriptdir="\$(cd "\$(dirname "\$0")" && pwd)"
+    fi
+else
+    if [ ! -d "${SDKPATH}" ]; then
+        echo >&2 "Warning: Unable to determine SDK install path from environment setup script location, using default of ${SDKPATH}."
+    fi
+    scriptdir="${SDKPATH}"
+fi
+END
+    sed -e "s#${SDKPATH}#\$scriptdir#g" "$script" >>"${script}.new"
+    mv "${script}.new" "${script}"
+
+    # Add variables from SDK_EXTRA_VARS
+    cat <<END >>"$script"
+${@sdk_extra_var_lines(d)}
+END
+}
+
+python write_codebench_metadata () {
+    localdata = bb.data.createCopy(d)
+
+    # make sure we only use the WORKDIR value from 'd', or it can change
+    localdata.setVar('WORKDIR', d.getVar('WORKDIR'))
+
+    # make sure we only use the SDKTARGETSYSROOT value from 'd'
+    localdata.setVar('SDKTARGETSYSROOT', d.getVar('SDKTARGETSYSROOT'))
+    localdata.setVar('libdir', d.getVar('target_libdir', False))
+
+    write_cb_mbs_options(localdata, localdata.expand('${SDK_OUTPUT}/${SDKPATH}/cb-mbs-options-${REAL_MULTIMACH_TARGET_SYS}'))
+
+    if not d.getVar("MLPREFIX"):
+        variants = d.getVar("MULTILIB_VARIANTS") or ""
+        for item in variants.split():
+            ld2 = localdata.createCopy()
+            # Load overrides from 'd' to avoid having to reset the value...
+            overrides = d.getVar("OVERRIDES", False) + ":virtclass-multilib-" + item
+            ld2.setVar("OVERRIDES", overrides)
+            ld2.setVar("MLPREFIX", item + "-")
+
+            write_cb_mbs_options(ld2, ld2.expand('${SDK_OUTPUT}/${SDKPATH}/cb-mbs-options-${REAL_MULTIMACH_TARGET_SYS}'))
+}
+write_codebench_metadata[vardepsexclude] += "OVERRIDES"
+
+def write_cb_mbs_options(d, optionsfile):
+    # We don't care about flags like debugging, optimization. TUNE_CCARGS is
+    # already covered.
+    l = d.createCopy()
+    l.setVar('TARGET_CFLAGS', '')
+    l.setVar('TARGET_CXXFLAGS', '')
+    l.setVar('TARGET_LDFLAGS', '')
+    options = get_cb_options(l)
+    bb.utils.mkdirhier(os.path.dirname(optionsfile))
+    with open(optionsfile, 'w') as f:
+        f.writelines('%s=%s\n' % (k, d.expand(v)) for k, v in sorted(options.items()))
+
+write_cb_mbs_options[vardeps] += "${@' '.join('CB_MBS_OPTIONS[%s]' % f for f in (d.getVarFlags('CB_MBS_OPTIONS') or []))}"
+
+def get_cb_options(d):
+    """Set default CodeBench metadata values based upon BitBake build flags."""
+    import shlex
+    import subprocess
+    from fnmatch import fnmatchcase
+
+    options = d.getVarFlags('CB_MBS_OPTIONS') or {}
+
+    l = d.createCopy()
+    l.finalize()
+    l.setVar('DEBUG_PREFIX_MAP', '')
+    l.setVar('STAGING_DIR_TARGET', '$SDKTARGETSYSROOT')
+
+    features = d.getVar('TUNE_FEATURES').split()
+    for feature, settings in (d.getVarFlags('CB_MBS_OPTIONS_FEATURES_MAP') or {}).items():
+        if feature.startswith('-'):
+            enabled = feature[1:] not in features
+        else:
+            enabled = feature in features
+        if enabled:
+            for setting in settings.split():
+                skey, svalue = setting.split('=', 1)
+                if setting and not options.get(skey):
+                    options[skey] = svalue
+
+    cflags = shlex.split(l.getVar('TARGET_CFLAGS'))
+    cxxflags = shlex.split(l.getVar('TARGET_CXXFLAGS'))
+    ldflags = shlex.split(l.getVar('TARGET_LDFLAGS'))
+
+    ccargs = shlex.split(l.getVar('TARGET_CC_ARCH'))
+    cflags.extend(ccargs)
+    cxxflags.extend(ccargs)
+    ldflags.extend(ccargs)
+
+    ignored = d.getVar('CB_MBS_IGNORED_FLAGS').split()
+    cflags = [a for a in cflags if not any(fnmatchcase(a, p) for p in ignored)]
+    cxxflags = [a for a in cxxflags if not any(fnmatchcase(a, p) for p in ignored)]
+    ldflags = [a for a in ldflags if not any(fnmatchcase(a, p) for p in ignored)]
+
+    check_cflags, check_cxxflags = list(cflags), list(cxxflags)
+    for flag, settings in (d.getVarFlags('CB_MBS_OPTIONS_FLAGS_MAP') or {}).items():
+        for setting in settings.split():
+            skey, svalue = setting.split('=', 1)
+            if flag in check_cflags:
+                if flag in cflags:
+                    cflags.remove(flag)
+                if setting and not options.get(skey):
+                    options[skey] = svalue
+
+            if flag in check_cxxflags:
+                if flag in cxxflags:
+                    cxxflags.remove(flag)
+                if setting and not options.get(skey):
+                    options[skey] = svalue
+
+    for flag, settings in (d.getVarFlags('CB_MBS_OPTIONS_FLAGS_VALUE_MAP') or {}).items():
+        for setting in settings.split():
+            skey, svalue = setting.split('=', 1)
+            for check_flag in check_cflags:
+                if check_flag.startswith(flag + '='):
+                    _, check_value = check_flag.split('=', 1)
+                    if check_flag in cflags:
+                        cflags.remove(check_flag)
+                    if setting and not options.get(skey):
+                        options[skey] = svalue + check_value
+
+            for check_flag in check_cxxflags:
+                if check_flag.startswith(flag + '='):
+                    _, check_value = check_flag.split('=', 1)
+                    if check_flag in cxxflags:
+                        cxxflags.remove(check_flag)
+                    if setting and not options.get(skey):
+                        options[skey] = svalue + check_value
+
+    for flag, settings in (d.getVarFlags('CB_MBS_OPTIONS_CC_FLAGS_MAP') or {}).items():
+        for setting in settings.split():
+            if flag in check_cflags:
+                if flag in cflags:
+                    cflags.remove(flag)
+                if setting:
+                    skey, svalue = setting.split('=', 1)
+                    skey = 'gnu.c.' + skey
+                    svalue = 'gnu.c.' + svalue
+                    if not options.get(skey):
+                        options[skey] = svalue
+
+            if flag in check_cxxflags:
+                if flag in cxxflags:
+                    cxxflags.remove(flag)
+                if setting:
+                    skey, svalue = setting.split('=', 1)
+                    skey = 'gnu.cpp.' + skey
+                    svalue = 'gnu.cpp.compiler.' + svalue
+                    if not options.get(skey):
+                        options[skey] = svalue
+
+    ignored = d.getVar('CB_MBS_IGNORED_EXTRA_FLAGS').split()
+    cflags = [a for a in cflags if not any(fnmatchcase(a, p) for p in ignored)]
+    cxxflags = [a for a in cxxflags if not any(fnmatchcase(a, p) for p in ignored)]
+    ldflags = [a for a in ldflags if not any(fnmatchcase(a, p) for p in ignored)]
+
+    if cflags:
+        options['gnu.c.compiler*option.misc.other'] = subprocess.list2cmdline(cflags)
+    if cxxflags:
+        options['gnu.cpp.compiler*option.other.other'] = subprocess.list2cmdline(cxxflags)
+    if ldflags:
+        options['gnu.c.link*option.ldflags'] = subprocess.list2cmdline(ldflags)
+        options['gnu.cpp.link*option.flags'] = subprocess.list2cmdline(ldflags)
+
+    for option, value in list(options.items()):
+        value = d.expand(value)
+        if not value:
+            del options[option]
+        else:
+            # Force immediate expansion, so we use target overrides regardless
+            # of the context in which the flags are used
+            options[option] = value
+
+    return options

--- a/meta-sokol-flex-common/classes/sdk_extra_vars.bbclass
+++ b/meta-sokol-flex-common/classes/sdk_extra_vars.bbclass
@@ -1,0 +1,32 @@
+# In most cases, it's better to use environment-setup.d for this, but there
+# are cases where it's useful to add to the main env setup script.
+
+EXTRA_SDK_VARS ?= ""
+EXTRA_EXPORTED_SDK_VARS ?= ""
+EXTRA_SDK_LINES ?= ""
+
+def sdk_extra_var_lines(d):
+    lines = []
+    for var in d.getVar('EXTRA_SDK_VARS', True).split():
+        try:
+            var, shvar = var.split(':', 1)
+        except ValueError:
+            shvar = var
+        lines.append('%s="%s"' % (shvar, d.getVar(var, True) or ""))
+
+    for var in d.getVar('EXTRA_EXPORTED_SDK_VARS', True).split():
+        try:
+            var, shvar = var.split(':', 1)
+        except ValueError:
+            shvar = var
+        lines.append('export %s="%s"' % (shvar, d.getVar(var, True) or ""))
+
+    extra_lines = d.getVar('EXTRA_SDK_LINES', True).replace('\\n', '\n').split('\n')
+    lines.extend(extra_lines)
+    return '\n'.join(lines)
+
+toolchain_shared_env_script:append () {
+    cat <<END >>"$script"
+${@sdk_extra_var_lines(d)}
+END
+}

--- a/meta-sokol-flex-common/classes/sdk_extra_vars.bbclass
+++ b/meta-sokol-flex-common/classes/sdk_extra_vars.bbclass
@@ -13,17 +13,34 @@ def sdk_extra_var_lines(d):
     lines = []
     for var in d.getVar('EXTRA_SDK_VARS', True).split():
         try:
-            var, shvar = var.split(':', 1)
+            var, value = var.rsplit('=', 1)
+        except ValueError:
+            value = None
+
+        try:
+            var, shvar = var.rsplit(':', 1)
         except ValueError:
             shvar = var
-        lines.append('%s="%s"' % (shvar, d.getVar(var, True) or ""))
+
+        if value is None:
+            value = d.getVar(var) or ""
+
+        lines.append('%s="%s"' % (shvar, value))
 
     for var in d.getVar('EXTRA_EXPORTED_SDK_VARS', True).split():
         try:
-            var, shvar = var.split(':', 1)
+            var, value = var.rsplit('=', 1)
+        except ValueError:
+            value = None
+
+        try:
+            var, shvar = var.rsplit(':', 1)
         except ValueError:
             shvar = var
-        lines.append('export %s="%s"' % (shvar, d.getVar(var, True) or ""))
+
+        if value is None:
+            value = d.getVar(var) or ""
+        lines.append('export %s="%s"' % (shvar, value))
 
     extra_lines = d.getVar('EXTRA_SDK_LINES', True).replace('\\n', '\n').split('\n')
     lines.extend(extra_lines)

--- a/meta-sokol-flex-common/classes/sdk_extra_vars.bbclass
+++ b/meta-sokol-flex-common/classes/sdk_extra_vars.bbclass
@@ -1,3 +1,7 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# SPDX-License-Identifier: MIT
+# ---------------------------------------------------------------------------------------------------------------------
+
 # In most cases, it's better to use environment-setup.d for this, but there
 # are cases where it's useful to add to the main env setup script.
 

--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -13,7 +13,6 @@ MAINTAINER = "Siemens Digital Industries Software <embedded_support@mentor.com>"
 HOME_URL = "https://www.plm.automation.siemens.com/global/en/products/embedded/flex-os.html"
 SUPPORT_URL = "https://support.sw.siemens.com/"
 BUG_REPORT_URL = "https://support.sw.siemens.com/"
-ADE_PROVIDER = "${DISTRO_NAME}"
 TARGET_VENDOR = "-flex"
 SDK_VENDOR = "-flexsdk"
 

--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -288,19 +288,19 @@ METADATA_REVISION := "${@base_detect_revision(d)}"
 SDK_DEPLOY:sokol-flex = "${DEPLOY_DIR_SDK}"
 DEPLOY_DIR_SDK ?= "${DEPLOY_DIR}/sdk"
 
-# Define a common identifier for a unique SDK, removing SDK_ARCH, switching from
-# TUNE_PKGARCH to MACHINE, and including image name and SDK version.
-SDK_IDENTIFIER ?= "${IMAGE_BASENAME}-${MACHINE}-${SDK_VERSION}"
-
-# Set the SDK title. SDK_VERSION is left out, as it's explicitly shown in the installer
-SDK_TITLE ?= "SDK for ${IMAGE_BASENAME}-${MACHINE}"
-
 # Use distro rather than oecore
 SDK_NAME_PREFIX = "${DISTRO}"
 
 # Adjust installer name and default install path
 SDK_NAME = "${SDK_NAME_PREFIX}-${SDK_VERSION}-${IMAGE_BASENAME}-${MACHINE}"
 SDKPATHINSTALL = "~/${DISTRO}/sdk/${SDK_VERSION}/${IMAGE_BASENAME}-${MACHINE}"
+
+# Set the SDK title. SDK_VERSION is left out, as it's explicitly shown in the installer
+SDK_TITLE ?= "${DISTRO_NAME} ${IMAGE_BASENAME} SDK for ${MACHINE}"
+SDK_TITLE:task-populate-sdk-ext:mel = "${DISTRO_NAME} ${IMAGE_BASENAME} Extensible SDK for ${MACHINE}"
+
+# Define a common identifier for a unique SDK, to be set in CodeBench metadata
+SDK_IDENTIFIER ?= "${SDKMACHINE}-${IMAGE_BASENAME}-${MACHINE}-${SDK_VERSION}"
 
 # As we remove the toolchain from the sdk, naming it 'toolchain' is not
 # accurate, and sdk better describes what it is anyway. We also include

--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -28,7 +28,7 @@ SCRIPTS_VERSION ?= "1"
 BSP_VERSION ?= "0"
 PATCH_VERSION ?= "0"
 
-SDK_VERSION := "${@'${DISTRO_VERSION}'.replace('snapshot-${DATE}','snapshot')}"
+SDK_VERSION := "${@'${DISTRO_VERSION}'.replace('+snapshot-${DATE}','-snapshot')}"
 DISTRO_VERSION[vardepsexclude] = "DATE"
 SDK_VERSION[vardepsexclude] = "DATE"
 

--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -288,10 +288,9 @@ METADATA_REVISION := "${@base_detect_revision(d)}"
 SDK_DEPLOY:sokol-flex = "${DEPLOY_DIR_SDK}"
 DEPLOY_DIR_SDK ?= "${DEPLOY_DIR}/sdk"
 
-# Define a common identifier for a unique SDK, switching from SDK_ARCH to
-# SDKMACHINE, from TUNE_PKGARCH to MACHINE, and including image name and the
-# version.
-SDK_IDENTIFIER ?= "${SDKMACHINE}-${IMAGE_BASENAME}-${MACHINE}-${SDK_VERSION}"
+# Define a common identifier for a unique SDK, removing SDK_ARCH, switching from
+# TUNE_PKGARCH to MACHINE, and including image name and SDK version.
+SDK_IDENTIFIER ?= "${IMAGE_BASENAME}-${MACHINE}-${SDK_VERSION}"
 
 # Set the SDK title. SDK_VERSION is left out, as it's explicitly shown in the installer
 SDK_TITLE ?= "SDK for ${IMAGE_BASENAME}-${MACHINE}"
@@ -303,10 +302,10 @@ SDK_NAME_PREFIX = "${DISTRO}"
 SDK_NAME = "${SDK_NAME_PREFIX}-${SDK_IDENTIFIER}"
 SDKPATHINSTALL = "/opt/${SDK_NAME_PREFIX}/${SDK_IDENTIFIER}"
 
-# As we remove the toolchain from the sdk, naming it 'toolchain' is not #
+# As we remove the toolchain from the sdk, naming it 'toolchain' is not
 # accurate, and sdk better describes what it is anyway. We also include
 # SDK_VERSION in our SDK_NAME, so no need to duplicate it here.
-TOOLCHAIN_OUTPUTNAME ?= "sdk-${SDK_NAME}"
+TOOLCHAIN_OUTPUTNAME ?= "sdk-${SDKMACHINE}-${SDK_NAME}"
 
 # Restore the default to buildtools-tarball, as that recipe sets it with ?=
 TOOLCHAIN_OUTPUTNAME:pn-buildtools-tarball = "${SDK_ARCH}-buildtools-nativesdk-standalone-${DISTRO_VERSION}"

--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -307,6 +307,10 @@ EXTERNAL_SETUP_SCRIPT_VARS += "REAL_MULTIMACH_TARGET_SYS"
 EXTERNAL_REAL_MULTIMACH_TARGET_SYS ??= "${REAL_MULTIMACH_TARGET_SYS}"
 CB_MBS_OPTIONS[general.yocto.sdk.value] = "${EXTERNAL_REAL_MULTIMACH_TARGET_SYS}"
 
+# Include metadata for CodeBench in the SDK
+SDKIMAGE_FEATURES:append = " codebench-metadata"
+IMAGE_CLASSES += "sdk_codebench_metadata"
+
 # This allows us to control what base target packages are installed for the
 # configured multilibs, by altering SDK_MULTILIB_VARIANTS to differ from
 # MULTILIB_VARIANTS. We also append meta-environment to obey

--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -32,9 +32,6 @@ SDK_VERSION := "${@'${DISTRO_VERSION}'.replace('snapshot-${DATE}','snapshot')}"
 DISTRO_VERSION[vardepsexclude] = "DATE"
 SDK_VERSION[vardepsexclude] = "DATE"
 
-SDK_NAME = "${DISTRO}-${TCLIBC}-${SDK_ARCH}-${IMAGE_BASENAME}-${TUNE_PKGARCH}"
-SDKPATHINSTALL = "/opt/${DISTRO}/${SDK_VERSION}"
-
 # This is a single libc DISTRO, so exclude it from tmpdir name
 TCLIBCAPPEND = ""
 
@@ -291,9 +288,25 @@ METADATA_REVISION := "${@base_detect_revision(d)}"
 SDK_DEPLOY:sokol-flex = "${DEPLOY_DIR_SDK}"
 DEPLOY_DIR_SDK ?= "${DEPLOY_DIR}/sdk"
 
-# As we remove the toolchain from the sdk, naming it 'toolchain' is not
-# accurate, and sdk better describes what it is anyway.
-TOOLCHAIN_OUTPUTNAME ?= "${SDK_NAME}-sdk-${SDK_VERSION}"
+# Define a common identifier for a unique SDK, switching from SDK_ARCH to
+# SDKMACHINE, from TUNE_PKGARCH to MACHINE, and including image name and the
+# version.
+SDK_IDENTIFIER ?= "${SDKMACHINE}-${IMAGE_BASENAME}-${MACHINE}-${SDK_VERSION}"
+
+# Set the SDK title. SDK_VERSION is left out, as it's explicitly shown in the installer
+SDK_TITLE ?= "SDK for ${IMAGE_BASENAME}-${MACHINE}"
+
+# Use distro rather than oecore
+SDK_NAME_PREFIX = "${DISTRO}"
+
+# Use the SDK identifier
+SDK_NAME = "${SDK_NAME_PREFIX}-${SDK_IDENTIFIER}"
+SDKPATHINSTALL = "/opt/${SDK_NAME_PREFIX}/${SDK_IDENTIFIER}"
+
+# As we remove the toolchain from the sdk, naming it 'toolchain' is not #
+# accurate, and sdk better describes what it is anyway. We also include
+# SDK_VERSION in our SDK_NAME, so no need to duplicate it here.
+TOOLCHAIN_OUTPUTNAME ?= "sdk-${SDK_NAME}"
 
 # Restore the default to buildtools-tarball, as that recipe sets it with ?=
 TOOLCHAIN_OUTPUTNAME:pn-buildtools-tarball = "${SDK_ARCH}-buildtools-nativesdk-standalone-${DISTRO_VERSION}"

--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -298,9 +298,9 @@ SDK_TITLE ?= "SDK for ${IMAGE_BASENAME}-${MACHINE}"
 # Use distro rather than oecore
 SDK_NAME_PREFIX = "${DISTRO}"
 
-# Use the SDK identifier
-SDK_NAME = "${SDK_NAME_PREFIX}-${SDK_IDENTIFIER}"
-SDKPATHINSTALL = "/opt/${SDK_NAME_PREFIX}/${SDK_IDENTIFIER}"
+# Adjust installer name and default install path
+SDK_NAME = "${SDK_NAME_PREFIX}-${SDK_VERSION}-${IMAGE_BASENAME}-${MACHINE}"
+SDKPATHINSTALL = "/opt/${DISTRO}/${SDK_VERSION}/sdk/${IMAGE_BASENAME}-${MACHINE}"
 
 # As we remove the toolchain from the sdk, naming it 'toolchain' is not
 # accurate, and sdk better describes what it is anyway. We also include

--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -300,7 +300,7 @@ SDK_NAME_PREFIX = "${DISTRO}"
 
 # Adjust installer name and default install path
 SDK_NAME = "${SDK_NAME_PREFIX}-${SDK_VERSION}-${IMAGE_BASENAME}-${MACHINE}"
-SDKPATHINSTALL = "/opt/${DISTRO}/${SDK_VERSION}/sdk/${IMAGE_BASENAME}-${MACHINE}"
+SDKPATHINSTALL = "~/${DISTRO}/sdk/${SDK_VERSION}/${IMAGE_BASENAME}-${MACHINE}"
 
 # As we remove the toolchain from the sdk, naming it 'toolchain' is not
 # accurate, and sdk better describes what it is anyway. We also include

--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -320,15 +320,11 @@ IMAGE_CLASSES += "image-sdk-multilib-variants"
 # Cull duplicate/invalid files for windows SDKMACHINEs
 IMAGE_CLASSES += "${@bb.utils.contains('BBFILE_COLLECTIONS', 'sokol-flex-staging', 'win_sdk_cull', '', d)}"
 
-# We need to ensure we can distribute downloads for SDK/ADE builds
+# We need to ensure we can distribute downloads for SDK builds
 IMAGE_CLASSES += "archive_sdk_downloads"
 
 # Create a 'latest' symlink for the SDK
 IMAGE_CLASSES += "sdk_latest_link"
-
-# If meta-flex-private is available, pull in the populate-ade class
-ADE_IMAGE_CLASS = "${@bb.utils.contains('BBFILE_COLLECTIONS', 'flex-private', 'populate_ade archive_ade_downloads', '', d)}"
-IMAGE_CLASSES += "${ADE_IMAGE_CLASS}"
 ## }}}1
 ## Sokol Flex OS Releases {{{1
 # Default image for our installers

--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -313,7 +313,7 @@ TOOLCHAIN_OUTPUTNAME:pn-buildtools-tarball = "${SDK_ARCH}-buildtools-nativesdk-s
 # Add KERNEL_* to the SDK environment (unexported) for use by the user
 TOOLCHAIN_TARGET_TASK_EXTRA += " sdk-env-kernelvars"
 
-# Set this so the ADE can set the right Yocto multilib display option
+# Set this so the SDK can set the right Yocto multilib display option
 EXTERNAL_SETUP_SCRIPT_VARS += "REAL_MULTIMACH_TARGET_SYS"
 EXTERNAL_REAL_MULTIMACH_TARGET_SYS ??= "${REAL_MULTIMACH_TARGET_SYS}"
 CB_MBS_OPTIONS[general.yocto.sdk.value] = "${EXTERNAL_REAL_MULTIMACH_TARGET_SYS}"

--- a/meta-sokol-flex-support/recipes-core/meta/codebench-makefile.bb
+++ b/meta-sokol-flex-support/recipes-core/meta/codebench-makefile.bb
@@ -1,0 +1,38 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# SPDX-License-Identifier: MIT
+# ---------------------------------------------------------------------------------------------------------------------
+
+SUMMARY = "SDK Makefile Fragment for CodeBench"
+LICENSE = "MIT"
+INHIBIT_DEFAULT_DEPS = "1"
+
+S = "${WORKDIR}"
+
+SDK_PRE_BUILD_TARGET ?= ""
+SDK_POST_BUILD_TARGET ?= ""
+
+do_compile () {
+    cat <<END >environment-setup.mk
+PATH:=@SDKPATH@/sysroots/${SDK_SYS}${prefix_nativesdk}/bin:\$(PATH)
+-include @SDKPATH@/sysroots/${MULTIMACH_TARGET_SYS}/environment-setup.d/*.mk
+-include @SDKPATH@/sysroots/${SDK_SYS}/environment-setup.d/*.mk
+END
+
+    {
+        echo 'SDK_CUSTOM_MAKEFILE="sysroots/${MULTIMACH_TARGET_SYS}/environment-setup.mk"'
+        if [ -n "${SDK_PRE_BUILD_TARGET}" ]; then
+            echo 'PRE_BUILD_TARGET="${SDK_PRE_BUILD_TARGET}"'
+        fi
+        if [ -n "${SDK_POST_BUILD_TARGET}" ]; then
+            echo 'POST_BUILD_TARGET="${SDK_POST_BUILD_TARGET}"'
+        fi
+    } >${BPN}.sh
+}
+
+do_install () {
+    install -d ${D}/environment-setup.d
+    install -m 0644 environment-setup.mk ${D}/
+    install -m 0644 ${BPN}.sh ${D}/environment-setup.d/
+}
+
+FILES:${PN} += "/environment-setup.mk /environment-setup.d"

--- a/meta-sokol-flex-support/recipes-core/meta/nativesdk-relocate-makefile.bb
+++ b/meta-sokol-flex-support/recipes-core/meta/nativesdk-relocate-makefile.bb
@@ -1,0 +1,23 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# SPDX-License-Identifier: MIT
+# ---------------------------------------------------------------------------------------------------------------------
+
+SUMMARY = "Relocate makefile fragments and environment-setup.d"
+LICENSE = "MIT"
+BASEDEPENDS = ""
+
+S = "${WORKDIR}"
+
+inherit nativesdk
+
+do_compile () {
+    echo '#!/bin/sh' >relocate.sh
+    echo 'for i in $1/sysroots/*/environment-setup.mk $1/sysroots/*/environment-setup.d/*.sh $1/sysroots/*/environment-setup.d/*.mk; do if [ -e "$i" ]; then sed -i -e "s,@SDKPATH@,$1,g" "$i"; fi; done' >>relocate.sh
+}
+
+do_install () {
+    install -d ${D}${SDKPATHNATIVE}/post-relocate-setup.d
+    install -m 0755 relocate.sh ${D}${SDKPATHNATIVE}/post-relocate-setup.d/${BPN}.sh
+}
+
+FILES:${PN} += "${SDKPATHNATIVE}"

--- a/scripts/setup-ubuntu
+++ b/scripts/setup-ubuntu
@@ -29,9 +29,6 @@ PKGS="$PKGS libgl1-mesa-dev libglu1-mesa-dev libsdl1.2-dev"
 # This is helpful to write images, and is in our documentation
 PKGS="$PKGS bmap-tools"
 
-# This is needed for Windows ADE
-PKGS="$PKGS zip"
-
 echo "Installing packages required to build Sokol Flex OS"
 $SUDO apt-get update
 $SUDO apt-get -y install $PKGS


### PR DESCRIPTION
- Use SDK naming
- Align with Yocto SDK
- Pull SDK enhancements and CodeBench metadata generation from other layers
- More pleasant title, aligned with upstream: `ADE for ${SDKMACHINE}-${IMAGE_BASENAME}-${MACHINE}-${SDK_VERSION}` -> `${DISTRO_NAME} ${IMAGE_BASENAME} SDK for ${MACHINE}`

JIRA: MELMR-1143

This is based upon #2. Rebased version of https://github.com/MentorEmbedded/meta-mentor/pull/1485.
