### PR TITLE
setup-flex-builddir: fix Layer init when no bbfile_collections are passed on

### DIFF
--- a/scripts/bb-determine-layers
+++ b/scripts/bb-determine-layers
@@ -237,7 +237,7 @@ class Layer(object):
 
         if not bbfile_collections:
             name = os.path.basename(layer_path)
-            l = Layer(layer_path, lconf, name, 0, 0, None, {})
+            l = Layer(layer_path, lconf, name, 0, 0, None, {}, {})
             layers.append(l)
 
         errors = []


### PR DESCRIPTION
Signed-off-by: Awais Belal <awais_belal@mentor.com>
Signed-off-by: Christopher Larson <chris_larson@mentor.com>
