### PR TITLE
local.conf.sample: restore default jobs/threads

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -86,11 +86,11 @@ USER_FEATURES += "~3g"
 # Disable near field communication support by default
 USER_FEATURES += "~nfc"
 
-# How many tasks bitbake should run in parallel
-BB_NUMBER_THREADS ?= "${@int(oe.utils.cpu_count() * 1.5)}"
+# How many tasks bitbake should run in parallel. Default: NUM_CPUS
+#BB_NUMBER_THREADS ?= "${@int(oe.utils.cpu_count())}"
 
-# How many jobs 'make' should run in parallel when compiling
-PARALLEL_MAKE ?= "-j ${@oe.utils.cpu_count() * 2}"
+# How many jobs 'make' should run in parallel when compiling. Default: NUM_CPUS
+#PARALLEL_MAKE ?= "-j ${@oe.utils.cpu_count()}"
 
 # Uncomment to exclude GPLv3 software from the build
 #INCOMPATIBLE_LICENSE = "GPL-3.0* LGPL-3.0*"


### PR DESCRIPTION
This reduces the quite aggressive default from `1.5*NUM_CORES` and `2.0*NUM_CORES` to `NUM_CORES` for both variables, which is oe-core's default.