### PR TITLE
WIP: Support oe-selftest + sokol-flex via a `selftest` distro feature

### DIFF
--- a/meta-sokol-flex-common/classes/feature_overrides.bbclass
+++ b/meta-sokol-flex-common/classes/feature_overrides.bbclass
@@ -12,14 +12,6 @@
 #   FEATUREOVERRIDES .= "${@bb.utils.contains('DISTRO_FEATURES', 'some-feature', ':feature-some-feature', '', d)}"
 #   FEATUREOVERRIDES .= "${@bb.utils.contains('MACHINE_FEATURES', 'some-bsp-feature', ':feature-some-bsp-feature', '', d)}"
 
-python add_feature_overrides () {
-    feature_overrides = filter(None, d.getVar('FEATUREOVERRIDES').split(':'))
-    if feature_overrides:
-        d.prependVar('OVERRIDES', ':'.join(unique_everseen(feature_overrides)) + ':')
-}
-add_feature_overrides[eventmask] = "bb.event.ConfigParsed"
-addhandler add_feature_overrides
-
 def unique_everseen(iterable):
     "List unique elements, preserving order. Remember all elements ever seen."
     # unique_everseen('AAAABBBCCDAABBB') --> A B C D
@@ -30,3 +22,6 @@ def unique_everseen(iterable):
     for element in itertools.filterfalse(seen.__contains__, iterable):
         seen_add(element)
         yield element
+
+FEATURE_OVERRIDES_PREPEND = "${@':'.join(unique_everseen(filter(None, d.getVar('FEATUREOVERRIDES').split(':'))))}"
+OVERRIDES:prepend = "${@d.getVar('FEATURE_OVERRIDES_PREPEND') + ':' if d.getVar('FEATURE_OVERRIDES_PREPEND') else ''}"

--- a/meta-sokol-flex-distro/conf/distro/include/no_sanity_distros.inc
+++ b/meta-sokol-flex-distro/conf/distro/include/no_sanity_distros.inc
@@ -1,0 +1,5 @@
+python no_sanity_distros () {
+    if bb.utils.contains('DISTRO_FEATURES', 'selftest', True, False, d):
+        d.delVar('SANITY_TESTED_DISTROS')
+}
+addhandler no_sanity_distros

--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -287,6 +287,18 @@ require classes/metadata_scm.bbclass
 METADATA_BRANCH := "${@base_detect_branch(d)}"
 METADATA_REVISION := "${@base_detect_revision(d)}"
 ## }}}1
+## OE Self Test {{{1
+# Use the expected dummy kernel
+PREFERRED_PROVIDER_virtual/kernel:feature-selftest = "linux-dummy"
+
+# Remove configuration items incompatible with oe-selftest
+INHERIT:remove:feature-selftest = "buildhistory rm_work"
+PRSERV_HOST:feature-selftest = ""
+
+# Selftest demands that this variable bit even exist in the metadata, so setting
+# to the empty string is insufficient
+require conf/distro/include/no_sanity_distros.inc
+## }}}1
 ## SDK & Application Development Environment {{{1
 # Use DEPLOY_DIR_ naming for consistency
 SDK_DEPLOY:sokol-flex = "${DEPLOY_DIR_SDK}"

--- a/meta-sokol-flex-distro/conf/layer.conf
+++ b/meta-sokol-flex-distro/conf/layer.conf
@@ -21,3 +21,6 @@ LAYERSERIES_COMPAT_sokol-flex-distro = "kirkstone"
 LAYERDEPENDS_sokol-flex-distro = "core sokol-flex-common"
 LAYERRECOMMENDS_sokol-flex-distro = "sokol-flex-support sokol-flex-staging sourcery flex-private tracing-layer flex-cve"
 LAYERRECOMMENDS_sokol-flex-distro += "openembedded-layer filesystems-layer networking-layer multimedia-layer gplv2"
+
+INHERIT:append = " feature_overrides"
+FEATUREOVERRIDES .= "${@bb.utils.contains('DISTRO_FEATURES', 'selftest', ':feature-selftest', '', d)}"


### PR DESCRIPTION
Based on #2. Currently not working, it's something related to the OVERRIDES usage for the distro feature. Switching `feature_overrides` to use inline python rather than an event *should* have resolved it, but did not.