### PR TITLE
Allow bblayers.conf to affect our bb-determine-layers script

### DIFF
--- a/scripts/bb-determine-layers
+++ b/scripts/bb-determine-layers
@@ -152,6 +152,7 @@ def process_arguments(cmdline_args):
     parser.add_argument('-d', '--distro', help='add layer(s) providing the specified DISTRO')
     parser.add_argument('-s', '--sdkmachine', help='add layer(s) providing the specified SDKMACHINE')
     parser.add_argument('-q', '--quiet', help='quiet mode, show no status/progress information', action='store_true')
+    parser.add_argument('-c', '--config-file', help='load a bitbake config file prior to the layer.conf')
     parser.add_argument('-v', '--verbose', help='increase verbosity', action='store_true')
 
     scriptdir = os.path.dirname(__file__)
@@ -500,6 +501,8 @@ def determine_layers(cmdline_opts):
 
     data = bb.data.init()
     bb.parse.init_parser(data)
+    if args.config_file:
+        data = bb.parse.handle(args.config_file, data, include=True)
 
     all_layers = Layers()
     collections = {}

--- a/scripts/setup-flex-builddir
+++ b/scripts/setup-flex-builddir
@@ -132,7 +132,7 @@ configure_builddir () {
         extralayernames="$extralayernames $layer"
     done
 
-    $layerdir/scripts/bb-determine-layers -g "$layerpaths" -l "$CORELAYERS $extralayernames" -o "$EXTRAFLEXLAYERS $OPTIONALLAYERS" -O "$layer_priority_overrides" -m "$MACHINE" -d "$DISTRO" "$@" >$layersfile
+    $layerdir/scripts/bb-determine-layers -g "$layerpaths" -l "$CORELAYERS $extralayernames" -o "$EXTRAFLEXLAYERS $OPTIONALLAYERS" -O "$layer_priority_overrides" -m "$MACHINE" -d "$DISTRO" -c "$BUILDDIR/conf/bblayers.conf" "$@" >$layersfile
     if [ $? -ne 0 ]; then
         echo >&2 "Error in execution of bb-determine-layers, aborting"
         return 1


### PR DESCRIPTION
This aligns with the behavior of bitbake itself and allows for us to use this mechanism to pull in additional layers whenever a vendor BSP layer is included, so we can apply necessary integration changes.

JIRA: MELMR-1099

Example usage in our bblayers.conf.sample:
```bitbake
# BSP Integration Layers
LAYERRECOMMENDS_meta-polarfire-soc-yocto-bsp:append = " mentor-vendor-polarfire-soc"
```

Migrated from <https://github.com/MentorEmbedded/meta-mentor/pull/1487>
