### PR TITLE
Use TOOLCHAINS_PATH in local.conf.sample directly

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -6,9 +6,8 @@ DISTRO = 'sokol-flex'
 # qemuarm, qemumips, qemuppc, qemux86, qemux86-64.
 MACHINE ??= "qemux86"
 
-# The path to the installed sourcery toolchain. This defaults to using the one
-# from the CodeBench we're installed in.
-#EXTERNAL_TOOLCHAIN ?= "/path/to/toolchain"
+# The path to the toolchains installed with CodeBench.
+#TOOLCHAINS_PATH ?= "/path/to/toolchains"
 
 # Uncomment to use the oe/yocto-built toolchain rather than the external
 #TCMODE:sokol-flex = "default"

--- a/scripts/setup-flex-builddir
+++ b/scripts/setup-flex-builddir
@@ -309,7 +309,7 @@ setup_builddir () {
             sedexpr='${FLEXDIR}/../../toolchains'
         fi
         if [ -d "$toolchains_path" ]; then
-            sed -i -e "s,^#\?EXTERNAL_TOOLCHAIN.*,TOOLCHAINS_PATH ?= \"$sedexpr\"," "$BUILDDIR/conf/local.conf"
+            sed -i -e "s,^#\?TOOLCHAINS_PATH.*,TOOLCHAINS_PATH ?= \"$sedexpr\"," "$BUILDDIR/conf/local.conf"
         fi
     else
         if [ -n "$MACHINE" ]; then

--- a/scripts/setup-flex-builddir
+++ b/scripts/setup-flex-builddir
@@ -309,7 +309,7 @@ setup_builddir () {
             sedexpr='${FLEXDIR}/../../toolchains'
         fi
         if [ -d "$toolchains_path" ]; then
-            sed -i -e "s,^#\?EXTERNAL_TOOLCHAIN.*,TOOLCHAINS_PATH ?= \"$toolchains_path\"," "$BUILDDIR/conf/local.conf"
+            sed -i -e "s,^#\?EXTERNAL_TOOLCHAIN.*,TOOLCHAINS_PATH ?= \"$sedexpr\"," "$BUILDDIR/conf/local.conf"
         fi
     else
         if [ -n "$MACHINE" ]; then


### PR DESCRIPTION
This aligns with how we do things, is simpler, in that it avoids changing variable names, and doesn't imply the user should use the wrong variable if they read `local.conf.sample` directly.