### PR TITLE
96boards-tools: fix LIC_FILES_CHKSUM

### DIFF
--- a/meta-sokol-flex-support/recipes-bsp/96boards-tools/96boards-tools_0.12.bb
+++ b/meta-sokol-flex-support/recipes-bsp/96boards-tools/96boards-tools_0.12.bb
@@ -7,7 +7,7 @@ HOMEPAGE = "https://github.com/96boards/96boards-tools"
 SECTION = "devel"
 
 LICENSE = "GPL-2.0-or-later"
-LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-or-later;md5=fed54355545ffd980b814dab4a3b312c"
 
 SRCREV = "a999d655417bb19ce8a476ff8c811e957748b661"
 SRC_URI = "git://github.com/96boards/96boards-tools;branch=master;protocol=https\


### PR DESCRIPTION
This fixes the LIC_FILES_CHKSUM for 96boards-tools which points
to an invalid file and updates the md5sum accordingly.

JIRA: https://jira.alm.mentorg.com/browse/SB-19969

Signed-off-by: Awais Belal <awais_belal@mentor.com>