### PR TITLE
Set TOOLCHAINS_PATH via the metadata

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -6,9 +6,9 @@ DISTRO = 'sokol-flex'
 # qemuarm, qemumips, qemuppc, qemux86, qemux86-64.
 MACHINE ??= "qemux86"
 
-# The path to the installed sourcery toolchain. This defaults to using the one
-# from the CodeBench we're installed in.
-#EXTERNAL_TOOLCHAIN ?= "/path/to/toolchain"
+# The path to the toolchains installed with CodeBench. Default value: ${FLEXDIR}/toolchains,
+# where FLEXDIR is the path to your Sokol Flex OS workspace.
+#TOOLCHAINS_PATH ?= "${FLEXDIR}/toolchains"
 
 # Uncomment to use the oe/yocto-built toolchain rather than the external
 #TCMODE:sokol-flex = "default"

--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -59,6 +59,7 @@ DISTRO_EXTRA_RRECOMMENDS += "udev-extraconf"
 
 # Paths
 FLEXDIR ?= "${COREBASE}/.."
+TOOLCHAINS_PATH ?= "${@d.getVar('FLEXDIR') + '/toolchains' if os.path.exists(d.getVar('FLEXDIR') + '/toolchains') else ''}"
 
 # Use a local PR server by default
 PRSERV_HOST ?= "localhost:0"

--- a/scripts/setup-flex-builddir
+++ b/scripts/setup-flex-builddir
@@ -300,17 +300,6 @@ setup_builddir () {
         cp $TEMPLATECONF/local.conf.sample $BUILDDIR/conf/local.conf
         echo "You had no local.conf file. This configuration file has therefore been"
         echo "created for you with some default values."
-
-        if [ -h "$FLEXDIR/toolchains" ]; then
-            toolchains_path="$FLEXDIR/toolchains"
-            sedexpr='${FLEXDIR}/toolchains'
-        else
-            toolchains_path="$FLEXDIR/../../toolchains"
-            sedexpr='${FLEXDIR}/../../toolchains'
-        fi
-        if [ -d "$toolchains_path" ]; then
-            sed -i -e "s,^#\?EXTERNAL_TOOLCHAIN.*,TOOLCHAINS_PATH ?= \"$toolchains_path\"," "$BUILDDIR/conf/local.conf"
-        fi
     else
         if [ -n "$MACHINE" ]; then
             echo "Configuring existing local.conf for $MACHINE"


### PR DESCRIPTION
There's no need to hardcode this knowledge in the setup scripts when we can set it in the metadata instead.

This makes https://github.com/MentorEmbedded/meta-sokol-flex/pull/17 unnecessary.