### PR TITLE
archive-release: implement download size sanity checks

### DIFF
--- a/meta-sokol-flex-support/recipes-core/meta/archive-release.bb
+++ b/meta-sokol-flex-support/recipes-core/meta/archive-release.bb
@@ -439,7 +439,7 @@ def checksummed_downloads(dl_by_layer_fn, dl_by_layer_dl_dir, dl_dir):
         dl_path = os.path.join(dl_dir, rel_path)
         if not os.path.exists(dl_path):
             # download is missing, probably excluded for license reasons
-            bb.warn('Download %s does not exist, excluding' % dl_path)
+            bb.warn('Download %s does not exist, excluding' % os.path.basename(dl_path))
             continue
 
         checksum = chksum_dl(dl_path)

--- a/meta-sokol-flex-support/recipes-core/meta/archive-release.bb
+++ b/meta-sokol-flex-support/recipes-core/meta/archive-release.bb
@@ -130,6 +130,11 @@ IMAGE_EXTENSIONS:remove = "${IMAGE_EXTENSIONS_EXCLUDED}"
 # }}}1
 
 # `downloads` artifact configuration {{{1
+ARCHIVE_DOWNLOAD_SIZE_CHECK ?= "\
+    WARN,gitshallow*,220M \
+    WARN,*,300M \
+"
+
 # Ensure we include all the uninative tarballs in our `downloads` artifact
 SRC_URI += "${@' '.join(uninative_urls(d)) if 'downloads' in '${RELEASE_ARTIFACTS}'.split() else ''}"
 
@@ -536,6 +541,55 @@ python do_archive_downloads () {
 }
 FETCHALL_TASK = "${@'do_archive_release_downloads_all' if oe.utils.inherits(d, 'archive-release-downloads') else 'do_fetchall'}"
 do_archive_downloads[depends] += "${@'${RELEASE_IMAGE}:${FETCHALL_TASK}' if '${RELEASE_IMAGE}' else ''}"
+
+python check_download_sanity () {
+    from fnmatch import fnmatch
+    from bb.monitordisk import convertGMK
+
+    check_items = d.getVar('ARCHIVE_DOWNLOAD_SIZE_CHECK').split()
+    checks = []
+    for item in check_items:
+        try:
+            mode, pattern, thresholdgmk = item.split(',')
+            threshold = convertGMK(thresholdgmk)
+        except ValueError:
+            bb.fatal('check_download_sanity: invalid entry `{}` in ARCHIVE_DOWNLOAD_SIZE_CHECK'.format(item))
+        else:
+            if mode not in ('WARN', 'ERROR', 'FATAL'):
+                bb.fatal('check_download_sanity: invalid mode `{}` in ARCHIVE_DOWNLOAD_SIZE_CHECK'.format(mode))
+
+            checks.append((mode, pattern, threshold, thresholdgmk))
+
+    dl_by_layer_fn = d.getVar('ARCHIVE_RELEASE_DL_BY_LAYER_PATH')
+    with open(dl_by_layer_fn, 'r') as f:
+        lines = f.readlines()
+
+    for layer_name, dl_path in (l.rstrip('\n').split('\t', 1) for l in lines):
+        try:
+            st = os.stat(dl_path)
+        except OSError:
+            continue
+        basepath = os.path.basename(dl_path)
+
+        for mode, pattern, threshold, thresholdgmk in checks:
+            if fnmatch(basepath, pattern) and st.st_size >= threshold:
+                msg = 'Download {} size ({}) exceeds configured threshold of {} for {}'.format(basepath, sizeof_fmt(st.st_size), sizeof_fmt(threshold), pattern)
+                if mode == 'WARN':
+                    bb.warn(msg)
+                elif mode == 'ERROR':
+                    bb.error(msg)
+                elif mode == 'FATAL':
+                    bb.fatal(msg)
+                break
+}
+do_archive_downloads[prefuncs] += "check_download_sanity"
+
+def sizeof_fmt(num, suffix='B'):
+    for unit in ['','Ki','Mi','Gi','Ti','Pi','Ei','Zi']:
+        if abs(num) < 1024.0:
+            return "%3.1f%s%s" % (num, unit, suffix)
+        num /= 1024.0
+    return "%.1f%s%s" % (num, 'Yi', suffix)
 
 archive_uninative_downloads () {
     # Ensure that uninative downloads are in ARCHIVE_RELEASE_DL_DIR, since


### PR DESCRIPTION
This will be useful as a sanity check to watch for unexpected large non-shallow git tarballs.

With this you'll get warnings such as this if a download is larger than expected:
```
WARNING: archive-release-1.0-r0 do_archive_downloads: Download gitshallow_git.yoctoproject.org.linux-yocto.git_3f298fc-1_v5.15.standard.qemuarm64.tar.gz size (213.5MiB) exceeds configured threshold of 200.0MiB for gitshallow*
```

The default configuration only warns for gitshallow > 220MiB or other downloads > 300MiB.

Based on https://github.com/MentorEmbedded/meta-sokol-flex/pull/22 to avoid conflicts.