### PR TITLE
staging/udev-extraconf: include fix for systemd automount issue from upstream

### DIFF
--- a/meta-sokol-flex-staging/recipes-core/udev/udev-extraconf_%.bbappend
+++ b/meta-sokol-flex-staging/recipes-core/udev/udev-extraconf_%.bbappend
@@ -4,20 +4,23 @@
 
 FILESEXTRAPATHS:prepend:feature-sokol-flex-staging := "${THISDIR}/${PN}:"
 SRC_URI:append:feature-sokol-flex-staging = " file://0001-udev-extraconf-mount.sh-add-LABELs-to-mountpoints.patch \
-             ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'file://systemd-udevd.service', '', d)} \
              file://0001-udev-extraconf-mount.sh-define-mount-prefix-using-a-.patch \
              file://0002-udev-extraconf-mount.sh-save-mount-name-in-our-tmp-f.patch \
              file://0003-udev-extraconf-mount.sh-only-mount-devices-on-hotplu.patch \
              file://0001-udev-extraconf-mount.sh-ignore-lvm-in-automount.patch"
 
-RDEPENDS:${PN}:append:feature-sokol-flex-staging = " util-linux-blkid"
+RDEPENDS:${PN}:append:feature-sokol-flex-staging = " util-linux-blkid ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'util-linux-lsblk', '', d)}"
 
 FILES:${PN}:append:feature-sokol-flex-staging = " ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', '${sysconfdir}/systemd/system/systemd-udevd.service', '', d)}"
 
-do_install:append:feature-sokol-flex-staging () {
-	if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
-		install -d ${D}${sysconfdir}/systemd/system
-		install ${WORKDIR}/systemd-udevd.service ${D}${sysconfdir}/systemd/system/systemd-udevd.service
-		sed -i 's|@systemd_unitdir@|${systemd_unitdir}|g' ${D}${sysconfdir}/systemd/system/systemd-udevd.service
+pkg_postinst:${PN} () {
+	if [ -e $D${systemd_unitdir}/system/systemd-udevd.service ]; then
+		sed -i "/\[Service\]/aMountFlags=shared" $D${systemd_unitdir}/system/systemd-udevd.service
+	fi
+}
+
+pkg_postrm:${PN} () {
+	if [ -e $D${systemd_unitdir}/system/systemd-udevd.service ]; then
+		sed -i "/MountFlags=shared/d" $D${systemd_unitdir}/system/systemd-udevd.service
 	fi
 }


### PR DESCRIPTION

This adds fix for systemd automount which has been fixed differently in
upstream oe-core layer.

Ref: https://github.com/openembedded/openembedded-core/commit/a3c93ec301a34413f91e3edb70c16454ebcdcdf2

With systemd-udev.service, the kernel and control sockets for systemd-udev
fails and hence systemd-udevd service fails to start which hangs the boot if
weston is enabled. This issue has been addressed upsrtream and fix is being included
here.

TODO: All the changes in flex-staging layer for udev-extraconf has been merged
upstream but will be part of 4.0.3 release which is planned to be out in Sep 2022.
For the time being, we are including the fix here but all these staging layer
changes should be dropped from here once 4.0.3 is out and we shift to that release.

JIRA-ID: SB-19773

Signed-off-by: ansar-rasool <ansar_rasool@mentor.com>