### PR TITLE
[kirkstone] sokol-flex: use the core packagegroup for weston feature packages

### DIFF
--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -239,7 +239,7 @@ INITRD_IMAGE_LIVE ?= "core-image-minimal-install-initramfs"
 # Additional package groups
 #
 # We prefer wayland/weston, unless the vendor supports x11 but not wayland.
-FEATURE_PACKAGES_flex-weston = "weston weston-init weston-examples"
+FEATURE_PACKAGES_flex-weston = "packagegroup-core-weston"
 FEATURE_PACKAGES_flex-x11 = "${FEATURE_PACKAGES_x11-base} ${FEATURE_PACKAGES_hwcodecs}"
 FEATURE_PACKAGES_graphics += "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', '${FEATURE_PACKAGES_flex-weston}', '', d)}"
 FEATURE_PACKAGES_graphics += "${@bb.utils.contains('DISTRO_FEATURES', 'x11', '${FEATURE_PACKAGES_flex-x11}', '', d)}"


### PR DESCRIPTION
packagegroup-core-weston makes more sense as the feature package for graphics
when using wayland. It provides the packages that we were using plus some
additional tools which would be helpful. This also allows us to align for this
component with vendor configurations.

JIRA: https://jira.alm.mentorg.com/browse/SB-19826

Signed-off-by: Awais Belal <awais_belal@mentor.com>