### PR TITLE
staging:rsync: import the missing files from merge

### DIFF
--- a/meta-sokol-flex-staging/dynamic-layers/gplv2/recipes-devtools/rsync/rsync/0001-If-we-re-cross-compiling-tell-the-user-to-run-mkroun.patch
+++ b/meta-sokol-flex-staging/dynamic-layers/gplv2/recipes-devtools/rsync/rsync/0001-If-we-re-cross-compiling-tell-the-user-to-run-mkroun.patch
@@ -1,0 +1,71 @@
+From 32da44bde46b8b78b25d37a172e7a57257ca5b8b Mon Sep 17 00:00:00 2001
+From: Wayne Davison <wayned@samba.org>
+Date: Tue, 1 Jan 2008 08:59:26 -0800
+Subject: [PATCH 1/4] If we're cross-compiling, tell the user to run
+ mkrounding on the target machine to build the
+ rounding.h file. (cherry picked from commit
+ f859d3ded6285c499898540ca4fb16f1e1a7d26b)
+
+Conflicts:
+
+	NEWS
+	configure.in
+---
+ Makefile.in  |    9 ++++++++-
+ NEWS         |    6 ++++++
+ configure.in |    2 ++
+ 3 files changed, 16 insertions(+), 1 deletion(-)
+
+diff --git a/Makefile.in b/Makefile.in
+index e9bd2c1..c2f779f 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -77,7 +77,14 @@ $(OBJS): $(HEADERS)
+ flist.o: rounding.h
+ 
+ rounding.h: mkrounding$(EXEEXT)
+-	./mkrounding$(EXEEXT) >rounding.h
++	@if test x@cross_compiling@ = xno; then \
++	    ./mkrounding$(EXEEXT) >rounding.h; \
++	else \
++	    echo "Copy the mkrounding$(EXEEXT) command to the target machine and run it like this:"; \
++	    echo "    ./mkrounding$(EXEEXT) >rounding.h"; \
++	    echo "Then copy the resulting rounding.h file to this build machine and rerun \"make\"."; \
++	    exit 1; \
++	fi
+ 
+ mkrounding$(EXEEXT): mkrounding.c rsync.h
+ 	@sed '1,/^struct file_struct/d; /^}/,$$d' <$(srcdir)/rsync.h >mkrounding.h
+diff --git a/NEWS b/NEWS
+index 9d23af0..bf6067e 100644
+--- a/NEWS
++++ b/NEWS
+@@ -4,6 +4,12 @@ Changes since 2.6.9:
+ 
+   BUG FIXES:
+ 
++    - If a file's data arrived successfully on the receiving side but the
++      rename of the tempory file to the destination file failed AND the
++      --remove-souce-files (or the deprecated --remove-sent-files) option
++      was specified, rsync no longer erroneously removes the associated
++      source file.
++
+     - Fixed the output of -ii when combined with one of the --*-dest options:
+       it now itemizes all the items, not just the changed ones.
+ 
+diff --git a/configure.in b/configure.in
+index 890a76b..aee2693 100644
+--- a/configure.in
++++ b/configure.in
+@@ -805,6 +805,8 @@ AC_SUBST(OBJ_SAVE)
+ AC_SUBST(OBJ_RESTORE)
+ AC_SUBST(CC_SHOBJ_FLAG)
+ AC_SUBST(BUILD_POPT)
++AC_SUBST(cross_compiling)
++
+ 
+ AC_CONFIG_FILES([Makefile lib/dummy zlib/dummy popt/dummy shconfig])
+ AC_OUTPUT
+-- 
+1.7.9.5
+

--- a/meta-sokol-flex-staging/dynamic-layers/gplv2/recipes-devtools/rsync/rsync/0002-Changed-the-creation-of-rounding.h-to-use-a-set-of-c.patch
+++ b/meta-sokol-flex-staging/dynamic-layers/gplv2/recipes-devtools/rsync/rsync/0002-Changed-the-creation-of-rounding.h-to-use-a-set-of-c.patch
@@ -1,0 +1,142 @@
+From 30932a3a7a3843c23577d0fdc6d61311b0454766 Mon Sep 17 00:00:00 2001
+From: Wayne Davison <wayned@samba.org>
+Date: Tue, 1 Jan 2008 10:27:19 -0800
+Subject: [PATCH 2/4] Changed the creation of rounding.h to use a set of
+ compile-time checks similar to how configure determines
+ the size of variables.
+
+Conflicts:
+
+	.gitignore
+	Makefile.in
+	configure.in
+---
+ Makefile.in  |   27 ++++++++++++++-------------
+ configure.in |    1 -
+ mkrounding.c |   46 +++++++++-------------------------------------
+ 3 files changed, 23 insertions(+), 51 deletions(-)
+
+diff --git a/Makefile.in b/Makefile.in
+index c2f779f..a660a75 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -76,21 +76,22 @@ $(OBJS): $(HEADERS)
+ 
+ flist.o: rounding.h
+ 
+-rounding.h: mkrounding$(EXEEXT)
+-	@if test x@cross_compiling@ = xno; then \
+-	    ./mkrounding$(EXEEXT) >rounding.h; \
+-	else \
+-	    echo "Copy the mkrounding$(EXEEXT) command to the target machine and run it like this:"; \
+-	    echo "    ./mkrounding$(EXEEXT) >rounding.h"; \
+-	    echo "Then copy the resulting rounding.h file to this build machine and rerun \"make\"."; \
++rounding.h: mkrounding.c rsync.h
++	@for r in 0 1 3; do \
++	    if $(CC) $(CFLAGS) $(LDFLAGS) -o mkrounding -DEXTRA_ROUNDING=$$r -I. $(srcdir)/mkrounding.c >/dev/null 2>&1; then \
++		echo "#define EXTRA_ROUNDING $$r" >rounding.h; \
++		if test -f "$$HOME/build_farm/build_test.fns"; then \
++		    echo "EXTRA_ROUNDING is $$r" >&2; \
++		fi; \
++		break; \
++	    fi; \
++	done
++	@rm -f mkrounding
++	@if test -f rounding.h; then : ; else \
++	    echo "Failed to create rounding.h!"; \
+ 	    exit 1; \
+ 	fi
+ 
+-mkrounding$(EXEEXT): mkrounding.c rsync.h
+-	@sed '1,/^struct file_struct/d; /^}/,$$d' <$(srcdir)/rsync.h >mkrounding.h
+-	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ -I. $(srcdir)/mkrounding.c
+-	@rm mkrounding.h
+-
+ tls$(EXEEXT): $(TLS_OBJ)
+ 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(TLS_OBJ) $(LIBS)
+ 
+@@ -119,7 +120,7 @@ proto:
+ 
+ clean: cleantests
+ 	rm -f *~ $(OBJS) $(TLS_OBJ) $(CHECK_PROGS) $(CHECK_OBJS) \
+-		mkrounding mkrounding.h rounding.h
++		mkrounding rounding.h
+ 
+ cleantests:
+ 	rm -rf ./testtmp*
+diff --git a/configure.in b/configure.in
+index aee2693..61458cf 100644
+--- a/configure.in
++++ b/configure.in
+@@ -805,7 +805,6 @@ AC_SUBST(OBJ_SAVE)
+ AC_SUBST(OBJ_RESTORE)
+ AC_SUBST(CC_SHOBJ_FLAG)
+ AC_SUBST(BUILD_POPT)
+-AC_SUBST(cross_compiling)
+ 
+ 
+ AC_CONFIG_FILES([Makefile lib/dummy zlib/dummy popt/dummy shconfig])
+diff --git a/mkrounding.c b/mkrounding.c
+index a5a5229..ec0f277 100644
+--- a/mkrounding.c
++++ b/mkrounding.c
+@@ -1,47 +1,19 @@
+ #include "rsync.h"
+ 
+-struct test1 {
+-    union file_extras extras1[1];
+-    struct {
+-#	include "mkrounding.h"
+-    } file;
+-};
+-
+-struct test2 {
+-    union file_extras extras2[2];
+-    struct {
+-#	include "mkrounding.h"
+-    } file;
+-};
++#define ARRAY_LEN (EXTRA_ROUNDING+1)
++#define SIZEOF(x) ((long int)sizeof (x))
+ 
+-struct test4 {
+-    union file_extras extras4[4];
+-    struct {
+-#	include "mkrounding.h"
+-    } file;
++struct test {
++    union file_extras extras[ARRAY_LEN];
++    struct file_struct file;
+ };
+ 
+-#define SIZE_TEST(n) (sizeof (struct test ## n) == EXTRA_LEN * n + sizeof (struct file_struct))
++#define ACTUAL_SIZE	SIZEOF(struct test)
++#define EXPECTED_SIZE	(SIZEOF(union file_extras) * ARRAY_LEN + SIZEOF(struct file_struct))
+ 
+  int main(UNUSED(int argc), UNUSED(char *argv[]))
+ {
+-    int cnt;
+-    if (SIZE_TEST(1))
+-	cnt = 0;
+-    else if (SIZE_TEST(2))
+-	cnt = 1;
+-    else if (SIZE_TEST(4))
+-	cnt = 3;
+-    else {
+-	fprintf(stderr, "Unable to determine required file_extras rounding!\n");
+-	cnt = 3;
+-    }
+-    if (cnt)
+-	fprintf(stderr, "Rounding file_extras in multiples of %d", cnt + 1);
+-    else
+-	fprintf(stderr, "No rounding needed for file_extras");
+-    fprintf(stderr, " (EXTRA_LEN=%d, FILE_STRUCT_LEN=%d)\n",
+-	    (int)EXTRA_LEN, (int)FILE_STRUCT_LEN);
+-    printf("#define EXTRA_ROUNDING %d\n", cnt);
++    static int test_array[1 - 2 * (ACTUAL_SIZE != EXPECTED_SIZE)];
++    test_array[0] = 0;
+     return 0;
+ }
+-- 
+1.7.9.5
+

--- a/meta-sokol-flex-staging/dynamic-layers/gplv2/recipes-devtools/rsync/rsync/0003-Renamed-mkrounding.c-to-rounding.c.patch
+++ b/meta-sokol-flex-staging/dynamic-layers/gplv2/recipes-devtools/rsync/rsync/0003-Renamed-mkrounding.c-to-rounding.c.patch
@@ -1,0 +1,104 @@
+From f41f666ea6b6bec85b40d4abb483b55438897f62 Mon Sep 17 00:00:00 2001
+From: Wayne Davison <wayned@samba.org>
+Date: Tue, 1 Jan 2008 10:34:27 -0800
+Subject: [PATCH 3/4] Renamed mkrounding.c to rounding.c. (cherry picked from
+ commit a5fd4b6e6e3d4649f0f65cd4a0385283fe69154c)
+
+Conflicts:
+
+	Makefile.in
+---
+ Makefile.in  |    8 ++++----
+ mkrounding.c |   19 -------------------
+ rounding.c   |   19 +++++++++++++++++++
+ 3 files changed, 23 insertions(+), 23 deletions(-)
+ delete mode 100644 mkrounding.c
+ create mode 100644 rounding.c
+
+diff --git a/Makefile.in b/Makefile.in
+index a660a75..8b5e2f1 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -76,9 +76,9 @@ $(OBJS): $(HEADERS)
+ 
+ flist.o: rounding.h
+ 
+-rounding.h: mkrounding.c rsync.h
++rounding.h: rounding.c rsync.h
+ 	@for r in 0 1 3; do \
+-	    if $(CC) $(CFLAGS) $(LDFLAGS) -o mkrounding -DEXTRA_ROUNDING=$$r -I. $(srcdir)/mkrounding.c >/dev/null 2>&1; then \
++	    if $(CC) $(CFLAGS) $(LDFLAGS) -o rounding -DEXTRA_ROUNDING=$$r -I. $(srcdir)/rounding.c >/dev/null 2>&1; then \
+ 		echo "#define EXTRA_ROUNDING $$r" >rounding.h; \
+ 		if test -f "$$HOME/build_farm/build_test.fns"; then \
+ 		    echo "EXTRA_ROUNDING is $$r" >&2; \
+@@ -86,7 +86,7 @@ rounding.h: mkrounding.c rsync.h
+ 		break; \
+ 	    fi; \
+ 	done
+-	@rm -f mkrounding
++	@rm -f rounding
+ 	@if test -f rounding.h; then : ; else \
+ 	    echo "Failed to create rounding.h!"; \
+ 	    exit 1; \
+@@ -120,7 +120,7 @@ proto:
+ 
+ clean: cleantests
+ 	rm -f *~ $(OBJS) $(TLS_OBJ) $(CHECK_PROGS) $(CHECK_OBJS) \
+-		mkrounding rounding.h
++		rounding rounding.h
+ 
+ cleantests:
+ 	rm -rf ./testtmp*
+diff --git a/mkrounding.c b/mkrounding.c
+deleted file mode 100644
+index ec0f277..0000000
+--- a/mkrounding.c
++++ /dev/null
+@@ -1,19 +0,0 @@
+-#include "rsync.h"
+-
+-#define ARRAY_LEN (EXTRA_ROUNDING+1)
+-#define SIZEOF(x) ((long int)sizeof (x))
+-
+-struct test {
+-    union file_extras extras[ARRAY_LEN];
+-    struct file_struct file;
+-};
+-
+-#define ACTUAL_SIZE	SIZEOF(struct test)
+-#define EXPECTED_SIZE	(SIZEOF(union file_extras) * ARRAY_LEN + SIZEOF(struct file_struct))
+-
+- int main(UNUSED(int argc), UNUSED(char *argv[]))
+-{
+-    static int test_array[1 - 2 * (ACTUAL_SIZE != EXPECTED_SIZE)];
+-    test_array[0] = 0;
+-    return 0;
+-}
+diff --git a/rounding.c b/rounding.c
+new file mode 100644
+index 0000000..ec0f277
+--- /dev/null
++++ b/rounding.c
+@@ -0,0 +1,19 @@
++#include "rsync.h"
++
++#define ARRAY_LEN (EXTRA_ROUNDING+1)
++#define SIZEOF(x) ((long int)sizeof (x))
++
++struct test {
++    union file_extras extras[ARRAY_LEN];
++    struct file_struct file;
++};
++
++#define ACTUAL_SIZE	SIZEOF(struct test)
++#define EXPECTED_SIZE	(SIZEOF(union file_extras) * ARRAY_LEN + SIZEOF(struct file_struct))
++
++ int main(UNUSED(int argc), UNUSED(char *argv[]))
++{
++    static int test_array[1 - 2 * (ACTUAL_SIZE != EXPECTED_SIZE)];
++    test_array[0] = 0;
++    return 0;
++}
+-- 
+1.7.9.5
+

--- a/meta-sokol-flex-staging/dynamic-layers/gplv2/recipes-devtools/rsync/rsync/0004-Improved-the-manpage-install-rules.patch
+++ b/meta-sokol-flex-staging/dynamic-layers/gplv2/recipes-devtools/rsync/rsync/0004-Improved-the-manpage-install-rules.patch
@@ -1,0 +1,31 @@
+From ae41600a129cc0ada5ce33b1c5c1afc8c3c9cb63 Mon Sep 17 00:00:00 2001
+From: Wayne Davison <wayned@samba.org>
+Date: Fri, 9 Nov 2007 18:12:40 +0000
+Subject: [PATCH 4/4] Improved the manpage install rules. (cherry picked from
+ commit c8dccf8fb4949ad8f2c25f86808b517a5b30faf9)
+
+Conflicts:
+
+	Makefile.in
+---
+ Makefile.in |    4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile.in b/Makefile.in
+index 8b5e2f1..de37ddc 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -63,8 +63,8 @@ install: all
+ 	${INSTALLCMD} ${INSTALL_STRIP} -m 755 rsync$(EXEEXT) ${DESTDIR}${bindir}
+ 	-mkdir -p ${DESTDIR}${mandir}/man1
+ 	-mkdir -p ${DESTDIR}${mandir}/man5
+-	${INSTALLMAN} -m 644 $(srcdir)/rsync.1 ${DESTDIR}${mandir}/man1
+-	${INSTALLMAN} -m 644 $(srcdir)/rsyncd.conf.5 ${DESTDIR}${mandir}/man5
++	if test -f $(srcdir)/rsync.1; then ${INSTALLMAN} -m 644 $(srcdir)/rsync.1 ${DESTDIR}${mandir}/man1; fi
++	if test -f $(srcdir)/rsyncd.conf.5; then ${INSTALLMAN} -m 644 $(srcdir)/rsyncd.conf.5 ${DESTDIR}${mandir}/man5; fi
+ 
+ install-strip:
+ 	$(MAKE) INSTALL_STRIP='-s' install
+-- 
+1.7.9.5
+

--- a/meta-sokol-flex-staging/dynamic-layers/gplv2/recipes-devtools/rsync/rsync/addrinfo.h
+++ b/meta-sokol-flex-staging/dynamic-layers/gplv2/recipes-devtools/rsync/rsync/addrinfo.h
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 1995, 1996, 1997, 1998, and 1999 WIDE Project.
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the project nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE PROJECT AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE PROJECT OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/**
+ * @file addrinfo.h
+ *
+ * Replacement getaddrinfo() for machines that don't have it.  The new
+ * getaddrinfo()/getnameinfo() interface is implemented on top of the
+ * traditional resolver calls.
+ **/
+
+#ifndef HAVE_GETADDRINFO
+
+#ifndef EAI_ADDRFAMILY
+/*
+ * Error return codes from getaddrinfo()
+ */
+#define	EAI_ADDRFAMILY	 1	/* address family for hostname not supported */
+#define	EAI_AGAIN	 2	/* temporary failure in name resolution */
+#define	EAI_BADFLAGS	 3	/* invalid value for ai_flags */
+#define	EAI_FAIL	 4	/* non-recoverable failure in name resolution */
+#define	EAI_FAMILY	 5	/* ai_family not supported */
+#define	EAI_MEMORY	 6	/* memory allocation failure */
+#define	EAI_NODATA	 7	/* no address associated with hostname */
+#define	EAI_NONAME	 8	/* hostname nor servname provided, or not known */
+#define	EAI_SERVICE	 9	/* servname not supported for ai_socktype */
+#define	EAI_SOCKTYPE	10	/* ai_socktype not supported */
+#define	EAI_SYSTEM	11	/* system error returned in errno */
+#define EAI_BADHINTS	12
+#define EAI_PROTOCOL	13
+#define EAI_MAX		14
+#endif /* ndef EAI_ADDRFAMILY */
+
+/*
+ * Flag values for getaddrinfo()
+ */
+
+#ifndef AI_PASSIVE
+
+#define	AI_PASSIVE	0x00000001 /* get address to use bind() */
+#define	AI_CANONNAME	0x00000002 /* fill ai_canonname */
+#define	AI_NUMERICHOST	0x00000004 /* prevent name resolution */
+/* valid flags for addrinfo */
+#define	AI_MASK		(AI_PASSIVE | AI_CANONNAME | AI_NUMERICHOST)
+
+#define	AI_ALL		0x00000100 /* IPv6 and IPv4-mapped (with AI_V4MAPPED) */
+#define	AI_V4MAPPED_CFG	0x00000200 /* accept IPv4-mapped if kernel supports */
+#define	AI_ADDRCONFIG	0x00000400 /* only if any address is assigned */
+#define	AI_V4MAPPED	0x00000800 /* accept IPv4-mapped IPv6 address */
+/* special recommended flags for getipnodebyname */
+#define	AI_DEFAULT	(AI_V4MAPPED_CFG | AI_ADDRCONFIG)
+
+/*
+ * Constants for getnameinfo()
+ */
+#define	NI_MAXHOST	1025
+#define	NI_MAXSERV	32
+
+/*
+ * Flag values for getnameinfo()
+ */
+#define	NI_NOFQDN	0x00000001
+#define	NI_NUMERICHOST	0x00000002
+#define	NI_NAMEREQD	0x00000004
+#define	NI_NUMERICSERV	0x00000008
+#define	NI_DGRAM	0x00000010
+
+struct addrinfo {
+	int	ai_flags;	/* AI_PASSIVE, AI_CANONNAME */
+	int	ai_family;	/* PF_xxx */
+	int	ai_socktype;	/* SOCK_xxx */
+	int	ai_protocol;	/* 0 or IPPROTO_xxx for IPv4 and IPv6 */
+	size_t	ai_addrlen;	/* length of ai_addr */
+	char	*ai_canonname;	/* canonical name for hostname */
+	struct sockaddr *ai_addr;	/* binary address */
+	struct addrinfo *ai_next;	/* next structure in linked list */
+};
+
+extern void freehostent(struct hostent *);
+extern char *gai_strerror(int);
+#endif /* AI_PASSIVE */
+#endif /* HAVE_GETADDRINFO */
+
+#ifndef HAVE_SOCKADDR_STORAGE
+struct sockaddr_storage {
+	unsigned long	align;
+	unsigned char	fill[128 - sizeof (unsigned long)];
+};
+#endif

--- a/meta-sokol-flex-staging/dynamic-layers/gplv2/recipes-devtools/rsync/rsync/force-protocol-version-29.patch
+++ b/meta-sokol-flex-staging/dynamic-layers/gplv2/recipes-devtools/rsync/rsync/force-protocol-version-29.patch
@@ -1,0 +1,12 @@
+diff -Naur old/rsync.h new/rsync.h
+--- old/rsync.h	2014-04-08 18:21:34.000000000 +1100
++++ new/rsync.h	2014-04-15 20:28:02.000000000 +1100
+@@ -82,7 +82,7 @@
+ 			     == ((unsigned)(b2) & (unsigned)(mask)))
+ 
+ /* update this if you make incompatible changes */
+-#define PROTOCOL_VERSION 30
++#define PROTOCOL_VERSION 29
+ 
+ /* We refuse to interoperate with versions that are not in this range.
+  * Note that we assume we'll work with later versions: the onus is on


### PR DESCRIPTION
During our preparation for the release previous release branches were merged
in the current however some patch and configuration files were missed. This
causes a build time warning/error depending on the package inclusion.
We fix this by simply importing the files from the previous release as the
version being used is the same.

JIRA: https://jira.alm.mentorg.com/browse/SB-19971

Signed-off-by: Awais Belal <awais_belal@mentor.com>