### PR TITLE
staging:96boards-tools: really fix resizing on the first boot

### DIFF
--- a/meta-sokol-flex-staging/recipes-bsp/96boards-tools/96boards-tools/0001-resize-helper-make-parted-not-prompt-for-user-interv.patch
+++ b/meta-sokol-flex-staging/recipes-bsp/96boards-tools/96boards-tools/0001-resize-helper-make-parted-not-prompt-for-user-interv.patch
@@ -1,14 +1,14 @@
-From e967b17c58393eedbfc6112ccd30597f157058a5 Mon Sep 17 00:00:00 2001
+From dd5e5f29a89e3f556d55767069828aa2832d6d56 Mon Sep 17 00:00:00 2001
 From: Awais Belal <awais_belal@mentor.com>
-Date: Wed, 10 Aug 2022 05:51:05 +0500
+Date: Wed, 17 Aug 2022 20:22:36 +0500
 Subject: [PATCH] resize-helper: make parted not prompt for user intervention
 
 If the device/part being resized is mounted parted asks for a confirmation
 and waits for user input which does not work well in automatic resizing use
-cases. We enable the script mode which prints a warning but continues without
-user intervention.
+cases. We achieve this by piping a confirmation to the prompt that is displayed
+for user input.
 
-Upstream-status: Pending
+Upstream-Status: Pending
 
 Signed-off-by: Awais Belal <awais_belal@mentor.com>
 ---
@@ -16,7 +16,7 @@ Signed-off-by: Awais Belal <awais_belal@mentor.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/resize-helper b/resize-helper
-index 86882f6..7c12cbe 100755
+index 86882f6..4fcdd45 100755
 --- a/resize-helper
 +++ b/resize-helper
 @@ -57,6 +57,6 @@ if [ "$PART_TABLE_TYPE" = "gpt" ]; then
@@ -24,7 +24,7 @@ index 86882f6..7c12cbe 100755
  	${PARTPROBE}
  fi
 -${PARTED} -m ${DEVICE} u s resizepart ${PART_ENTRY_NUMBER} ${END_SIZE}
-+${PARTED} -s -m ${DEVICE} u s resizepart ${PART_ENTRY_NUMBER} ${END_SIZE}
++echo "Yes" | ${PARTED} ---pretend-input-tty -m ${DEVICE} u s resizepart ${PART_ENTRY_NUMBER} ${END_SIZE}
  ${PARTPROBE}
  ${RESIZE2FS} "${ROOT_DEVICE}"
 -- 


### PR DESCRIPTION
Our earlier attempt failed due to a negligence of testing the fix with script
mode at runtime with a fresh install i.e. the change was run on an already
resized root so the issue did not show up.
This really fixes the issue by leveraging an internal option (pretend-tty-input)
of parted with the older approach of echoing and piping the confirmation to the
command.

JIRA: https://jira.alm.mentorg.com/browse/SB-19819

Signed-off-by: Awais Belal <awais_belal@mentor.com>