### PR TITLE
sokol-flex: remove BB_GIT_SHALLOW_REVS for linux-mel

### DIFF
--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -129,12 +129,6 @@ BB_GIT_SHALLOW_DEPTH_DEFAULT ?= "1"
 BB_GIT_SHALLOW_DEPTH ??= "${@'${BB_GIT_SHALLOW_DEPTH_DEFAULT}' if not '${BB_GIT_SHALLOW_REVS}' else '0'}"
 BB_GIT_SHALLOW_REVS ??= ""
 
-# For our kernel repository, we want to ship the user the history which they
-# can't easily re-acquire from upstream.
-LINUX_VERSION_TAG ??= "v${@'.'.join('${LINUX_VERSION}'.split('.')[:2])}"
-LINUX_VERSION ??= ""
-BB_GIT_SHALLOW_REVS:pn-linux-mel ??= "${@'${LINUX_VERSION_TAG}' if '${LINUX_VERSION_TAG}' and '${LINUX_VERSION}' else ''}"
-
 # Export path variables into the devshell for convenience
 OE_TOPDIR = "${TOPDIR}"
 OE_WORKDIR = "${WORKDIR}"


### PR DESCRIPTION
This was moved to meta-flex-ref-bsps where it belongs. It also hasn't been updated for linux-flex.
