### PR TITLE
sokol-flex: correct pre-release versions

### DIFF
--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -26,9 +26,11 @@ SCRIPTS_VERSION ?= "1"
 BSP_VERSION ?= "0"
 PATCH_VERSION ?= "0"
 
-SDK_VERSION := "${@'${DISTRO_VERSION}'.replace('+snapshot-${DATE}','-snapshot')}"
-DISTRO_VERSION[vardepsexclude] = "DATE"
-SDK_VERSION[vardepsexclude] = "DATE"
+SDK_VERSION = "${@d.getVar('DISTRO_VERSION').replace('+snapshot-${DATE}', '')}.${SDK_TIMESTAMP}"
+SDK_VERSION[vardepsexclude] += "SDK_TIMESTAMP"
+
+SDK_TIMESTAMP = "${@d.getVar('DATETIME')[:-2]}"
+SDK_TIMESTAMP[doc] = "The timestamp from the DATETIME variable, without seconds."
 
 # This is a single libc DISTRO, so exclude it from tmpdir name
 TCLIBCAPPEND = ""


### PR DESCRIPTION
Replace `+snapshot-${DATE}` in `DISTRO_VERSION` with `-alpha`, and replace `-alpha` in `SDK_VERSION` with the timestamp in seconds as a suffix.

JIRA: SB-20310, SB-20454

Previous values:
```bitbake
DISTRO_VERSION="13.0+snapshot-20220913"
SDK_VERSION="13.0-snapshot"
```

New values:
```bitbake
DISTRO_VERSION="13.0-alpha"
SDK_VERSION="13.0.202209161514"
```