### PR TITLE
pulseaudio: make module-switch-on-connect available

### DIFF
--- a/meta-sokol-flex-distro/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
+++ b/meta-sokol-flex-distro/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
@@ -13,4 +13,5 @@ RDEPENDS:pulseaudio-server:append:sokol-flex = "\
     pulseaudio-module-cli \
     pulseaudio-module-dbus-protocol \
     pulseaudio-module-echo-cancel \
+    pulseaudio-module-switch-on-connect \
 "


### PR DESCRIPTION
This is a small change to include pusleaudio module `module-switch-on-connect` in the release.
It was noticed while testing the audio playback through g-streamer that it will be more user friendly if we add this module. This module automatically changes the sink when a new audio device is connected to host machine.
