### PR TITLE
sokol-flex.conf: Fix section starting and ending

### DIFF
--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -197,7 +197,8 @@ DISTRO_FEATURES:append = " sokol-flex-staging"
 # Since many embedded systems don't have non-root users, allow autospawn for
 # root as well.
 PACKAGECONFIG:append:pn-pulseaudio = " autospawn-for-root"
-
+## }}}1
+### Inherits {{{1
 # We want information and history about build output
 INHERIT += "buildhistory"
 


### PR DESCRIPTION
In https://github.com/MentorEmbedded/meta-sokol-flex/pull/52/ ending of section and starting of next were accidentally removed. This commit fixes the section starting and ending.

Signed-off-by: Muhammad Hamza <muhammad_hamza@mentor.com>