### PR TITLE
Support on-target development for development-image, and other fixes

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -24,7 +24,7 @@ MACHINE ??= "qemux86"
 EXTRA_IMAGE_FEATURES ?= "multilib-runtime"
 
 # Image features for development-image
-IMAGE_FEATURES_DEVELOPMENT ?= "debug-tweaks"
+IMAGE_FEATURES_DEVELOPMENT ?= "debug-tweaks tools-sdk"
 IMAGE_FEATURES_DEVELOPMENT:append:feature-flex-bsp = " codebench-debug ssh-server-openssh tools-profile"
 
 # Image features for production-image

--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -256,7 +256,7 @@ PREFERRED_PROVIDER_virtual/docker = "docker-moby"
 #
 # We prefer wayland/weston, unless the vendor supports x11 but not wayland.
 FEATURE_PACKAGES_flex-weston = "packagegroup-core-weston"
-FEATURE_PACKAGES_flex-x11 = "${FEATURE_PACKAGES_x11-base} ${FEATURE_PACKAGES_hwcodecs}"
+FEATURE_PACKAGES_flex-x11 = "${FEATURE_PACKAGES_x11-base}"
 FEATURE_PACKAGES_graphics += "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', '${FEATURE_PACKAGES_flex-weston}', '', d)}"
 FEATURE_PACKAGES_graphics += "${@bb.utils.contains('DISTRO_FEATURES', 'x11', '${FEATURE_PACKAGES_flex-x11}', '', d)}"
 FEATURE_PACKAGES_tools-audio     ?= "packagegroup-tools-audio"

--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -68,13 +68,8 @@ PACKAGE_CLASSES ?= "package_ipk"
 
 # Sokol Flex OS's supported hosts
 SANITY_TESTED_DISTROS = "\
-    ubuntu-18.04 \n\
     ubuntu-20.04 \n\
-    centos-7* \n \
-    centoslinux-7* \n \
-    debian-10* \n \
-    rhel*-8* \n \
-    redhatenterprise*-8* \n \
+    ubuntu-22.04 \n\
 "
 
 # Sane default append for the kernel cmdline (not used by all BSPs)

--- a/meta-sokol-flex-support/recipes-core/images/flex-image.inc
+++ b/meta-sokol-flex-support/recipes-core/images/flex-image.inc
@@ -13,6 +13,6 @@ LICENSE = "MIT"
 
 inherit core-image
 
-IMAGE_FEATURES:append:sokol-flex = " splash ${@bb.utils.contains('COMBINED_FEATURES', 'alsa', ' tools-audio', '', d)}"
+IMAGE_FEATURES:append:sokol-flex = " splash ${@bb.utils.contains('COMBINED_FEATURES', 'alsa', ' hwcodecs tools-audio', '', d)}"
 IMAGE_INSTALL:append:sokol-flex = " util-linux-mkfs connman"
 IMAGE_INSTALL:append:sokol-flex = " ${@bb.utils.contains('BBFILE_COLLECTIONS', 'openembedded-layer', 'haveged' if not any_incompatible(d, ['haveged'], 'GPL-3.0-only') else '', '', d)}"


### PR DESCRIPTION
This PR adds 'tools-sdk' to 'IMAGE_FEATURES_DEVELOPMENT', so that we get support for on-target development.

While at it, also add hwcodecs image feature when alsa is in COMBINED_FEATURES, and remove FEATURE_PACKAGES_hwcodecs from x11 FEATURE_PACKAGES