### PR TITLE
sokol-flex.conf: Fix parsing error with swupdate in build config and …

### DIFF
--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -251,6 +251,7 @@ PREFERRED_PROVIDER_virtual/docker = "docker-moby"
 #
 # We prefer wayland/weston, unless the vendor supports x11 but not wayland.
 FEATURE_PACKAGES_flex-weston = "packagegroup-core-weston"
+FEATURE_PACKAGES_x11-base ?= "packagegroup-core-x11-base"
 FEATURE_PACKAGES_flex-x11 = "${FEATURE_PACKAGES_x11-base}"
 FEATURE_PACKAGES_graphics += "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', '${FEATURE_PACKAGES_flex-weston}', '', d)}"
 FEATURE_PACKAGES_graphics += "${@bb.utils.contains('DISTRO_FEATURES', 'x11', '${FEATURE_PACKAGES_flex-x11}', '', d)}"


### PR DESCRIPTION
…graphics in IMAGE_FEATURES.

* When swupdate is added in build configuration and graphics is added in IMAGE_FEATURES following error pops up.

  ERROR: ExpansionError during parsing /home/mhamza/mel-flex-13/meta-swupdate/recipes-extended/images/swupdate-image.bb bb.data_smart.ExpansionError: Failure expanding expression ${@multilib_pkg_extend(d,:do_package_write_ipk ${@multilib_pkg_extend(d,:do_packagedata 'packagegroup-core-standalone-sdk-target')}:do_package_write_ipk 'packagegroup-core-standalone-sdk-target')}:do_packagedata target-sdk-provides-dummy:do_package_write_ipk target-sdk-provides-dummy:do_packagedata base-files:do_package_write_ipk base-files:do_packagedata base-passwd:do_package_write_ipk base-passwd:do_packagedata busybox:do_package_write_ipk busybox:do_packagedata mtd-utils:do_package_write_ipk mtd-utils:do_packagedata mtd-utils-ubifs:do_package_write_ipk mtd-utils-ubifs:do_packagedata libconfig:do_package_write_ipk libconfig:do_packagedata swupdate:do_package_write_ipk swupdate:do_packagedata swupdate-www:do_package_write_ipk swupdate-www:do_packagedata initscripts:do_package_write_ipk initscripts:do_packagedata sysvinit:do_package_write_ipk sysvinit:do_packagedata util-linux-sfdisk:do_package_write_ipk util-linux-sfdisk:do_packagedata packagegroup-fsl-optee-imx:do_package_write_ipk packagegroup-fsl-optee-imx:do_packagedata run-postinsts:do_package_write_ipk run-postinsts:do_packagedata user-examples:do_package_write_ipk user-examples:do_packagedata ${@bb.utils.contains('DISTRO_FEATURES',:do_package_write_ipk ${@bb.utils.contains('DISTRO_FEATURES',:do_packagedata 'wayland',:do_package_write_ipk 'wayland',:do_packagedata ' packagegroup-core-weston',:do_package_write_ipk 'packagegroup-core-weston',:do_packagedata '',:do_package_write_ipk '',:do_packagedata d)} :do_package_write_ipk d)}:do_packagedata ${@bb.utils.contains('DISTRO_FEATURES',:do_package_write_ipk ${@bb.utils.contains('DISTRO_FEATURES',:do_packagedata 'x11',:do_package_write_ipk 'x11',:do_packagedata '${FEATURE_PACKAGES_x11-base} :do_package_write_ipk '${FEATURE_PACKAGES_x11-base}:do_packagedata ${FEATURE_PACKAGES_hwcodecs}',:do_package_write_ipk ${FEATURE_PACKAGES_hwcodecs}',:do_packagedata '',:do_package_write_ipk '',:do_packagedata d)}:do_package_write_ipk d)}:do_packagedata packagegroup-qt6:do_package_write_ipk packagegroup-qt6:do_packagedata glibc:do_package_write_ipk glibc:do_packagedata libgcc:do_package_write_ipk libgcc:do_packagedata libstdc++:do_package_write_ipk libstdc++:do_packagedata ${@['',:do_package_write_ipk ${@['',:do_packagedata 'base-passwd:do_package_write_ipk 'base-passwd:do_packagedata shadow'] [bool(d.getVar('EXTRA_USERS_PARAMS'))]}:do_package_write_ipk shadow'][bool(d.getVar('EXTRA_USERS_PARAMS'))]}:do_packagedata sdk-env-kernelvars:do_package_write_ipk sdk-env-kernelvars:do_packagedata ${@bb.utils.contains('BBFILE_COLLECTIONS',:do_package_write_ipk ${@bb.utils.contains('BBFILE_COLLECTIONS',:do_packagedata 'sokol-flex-support',:do_package_write_ipk 'sokol-flex-support',:do_packagedata 'codebench-makefile',:do_package_write_ipk 'codebench-makefile',:do_packagedata '',:do_package_write_ipk '',:do_packagedata d)}: do_package_write_ipk d)}:do_packagedata packagegroup-cross-canadian-imx8mpevk-flex:do_package_write_ipk packagegroup-cross-canadian-imx8mpevk-flex:do_packagedata nativesdk-qtcreator-flex:do_package_write_ipk nativesdk-qtcreator-flex:do_packagedata nativesdk-packagegroup-qt6-toolchain-host:do_package_write_ipk nativesdk-packagegroup-qt6-toolchain-host:do_packagedata nativesdk-relocate-makefile:do_package_write_ipk nativesdk-relocate-makefile:do_packagedata which triggered exception SyntaxError: invalid syntax (<expansion>, line 1)

* This error occured due to the reason that we are using FEATURE_PACKAGES_x11-base in our distro file. This is initialized in core-image.bbclass but swupdate-image does not inherit core-image.bbclass. Due to this we get this parsing error. Initialized this varaible in distro file to resolve the parsing error
* SB-20565

Signed-off-by: Noor Ahsan <noor_ahsan@mentor.com>