### PR TITLE
sokol-flex: default VENDOR based on MACHINE layer name

### DIFF
--- a/meta-sokol-flex-distro/conf/distro/include/vendor.inc
+++ b/meta-sokol-flex-distro/conf/distro/include/vendor.inc
@@ -1,0 +1,34 @@
+inherit layerdirs
+
+def layerdirs(d):
+    dirs = {}
+    for layerpath in d.getVar('BBLAYERS', True).split():
+        layerconf = os.path.join(layerpath, 'conf', 'layer.conf')
+
+        l = bb.data.init()
+        l.setVar('LAYERDIR', layerpath)
+        l = bb.parse.handle(layerconf, l)
+        l.expandVarref('LAYERDIR')
+
+        for layername in (l.getVar('BBFILE_COLLECTIONS', True) or '').split():
+            dirs[layername] = layerpath
+    return dirs
+
+def machine_layername(d):
+    machine_conf = bb.utils.which(d.getVar('BBPATH'), 'conf/machine/%s.conf' % d.getVar('MACHINE'))
+    if not machine_conf:
+        bb.warn('Failed to locate conf/machine/%s.conf in BBPATH' % d.getVar('MACHINE'))
+    else:
+        conf_layer = os.path.dirname(os.path.dirname(os.path.dirname(machine_conf)))
+
+        dirs = layerdirs(d)
+        for layername in (d.getVar('BBFILE_COLLECTIONS', True) or '').split():
+            layerdir = dirs.get(layername)
+            if conf_layer == layerdir:
+                return layername.replace('meta-', '')
+
+MACHINE_LAYERNAME := "${@machine_layername(d) or 'UNKNOWN'}"
+VENDOR ?= "${MACHINE_LAYERNAME}"
+VENDOR_CONF ?= "conf/vendor/${VENDOR}.conf"
+
+include ${VENDOR_CONF}

--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -3,8 +3,7 @@
 # ---------------------------------------------------------------------------------------------------------------------
 
 ## Vendor Integration {{{1
-VENDOR_CONF = "${@'conf/vendor/%s.conf' % d.getVar('VENDOR') if d.getVar('VENDOR') else ''}"
-require ${VENDOR_CONF}
+require conf/distro/include/vendor.inc
 ## }}}1
 ## Sokol Flex OS Base Configuration {{{1
 DISTRO_NAME = "Sokol Flex OS"


### PR DESCRIPTION

Determine the default vendor config filename based upon the layer name
of the layer which provides the MACHINE .conf, with meta- removed. For
example, for icicle-kit-es, `conf/vendor/polarfire-soc-yocto-bsp.conf`
would be included by default. Either VENDOR or VENDOR_CONF may be
overridden by a MACHINE, as will be the case for our official Sokol Flex
BSP machines.