### PR TITLE
Add support for RHEL9.

### DIFF
--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -70,6 +70,8 @@ PACKAGE_CLASSES ?= "package_ipk"
 SANITY_TESTED_DISTROS = "\
     ubuntu-20.04 \n\
     ubuntu-22.04 \n\
+    rhel*-9* \n \
+    redhatenterprise*-9* \n \
 "
 
 # Sane default append for the kernel cmdline (not used by all BSPs)

--- a/scripts/setup-rh
+++ b/scripts/setup-rh
@@ -9,7 +9,7 @@
 # version 2.  This program  is licensed "as is" without any warranty of any
 # kind, whether express or implied.
 
-packages="python38 \
+packages="python39 \
           patch diffstat git bzip2 tar \
           gzip gawk chrpath wget cpio perl file which \
           make gcc gcc-c++ rsync rpcgen \
@@ -27,9 +27,9 @@ if [ "$(id -u)" != "0" ]; then
 fi
 
 echo "Enabling any required repos"
-if grep -q "^Red Hat Enterprise Linux release 8" /etc/redhat-release 2>/dev/null; then
+if grep -q "^Red Hat Enterprise Linux release 9" /etc/redhat-release 2>/dev/null; then
     ARCH=$(/bin/arch)
-    subscription-manager repos --enable "codeready-builder-for-rhel-8-${ARCH}-rpms"
+    subscription-manager repos --enable "codeready-builder-for-rhel-9-${ARCH}-rpms"
 elif grep -q "^CentOS" /etc/redhat-release 2>/dev/null; then
     dnf config-manager --set-enabled PowerTools
 fi


### PR DESCRIPTION
SB-20046: The Flex OS should build on RHEL 9.

I had to re-create this PR. The old one got messed up.
@Noor-Ahsan this is the one which was already approved. Please merge it.
Previous PR URL is https://github.com/MentorEmbedded/meta-sokol-flex/pull/57/