### PR TITLE
sokol-flex.conf: Remove old version of Ubuntu

### DIFF
--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -67,7 +67,6 @@ PACKAGE_CLASSES ?= "package_ipk"
 
 # Sokol Flex OS's supported hosts
 SANITY_TESTED_DISTROS = "\
-    ubuntu-20.04 \n\
     ubuntu-22.04 \n\
     rhel*-9* \n \
     redhatenterprise*-9* \n \


### PR DESCRIPTION
We need to remove Ubuntu 20.04 from SANITY_TESTED_DISTROS because it is no longer a supported version as flex build host.
JIRA: SB-20045.
Signed-off-by: Akif akif_tariq@mentor.com