### PR TITLE
flex-image: remove entropy provider packages

### DIFF
--- a/meta-sokol-flex-support/recipes-core/images/flex-image.inc
+++ b/meta-sokol-flex-support/recipes-core/images/flex-image.inc
@@ -15,5 +15,4 @@ inherit core-image
 
 IMAGE_FEATURES:append:sokol-flex = " splash ${@bb.utils.contains('COMBINED_FEATURES', 'alsa', ' tools-audio', '', d)}"
 IMAGE_INSTALL:append:sokol-flex = " util-linux-mkfs connman"
-IMAGE_INSTALL:append:sokol-flex = " ${@bb.utils.contains('BBFILE_COLLECTIONS', 'openembedded-layer', 'haveged' if not any_incompatible(d, ['haveged'], 'GPL-3.0-only') else '', '', d)}"
 IMAGE_INSTALL:append:sokol-flex = " ${@bb.utils.contains_any('IMAGE_FEATURES', ['multimedia', 'graphics'], '${MACHINE_HWCODECS}', '', d)}"


### PR DESCRIPTION
We have decided to remove rng-tools and haveged like packages from our RFS on account of the fact that their use is controversial, they peg the CPU at startup, and most of all aren't needed anymore with modern SoCs which have dedicated RNG IP

JIRA-ID: SB-20711

Signed-off-by: Ahsan Hussain <ahsan_hussain@mentor.com>