### PR TITLE
Add pyrex support

### DIFF
--- a/scripts/build-setup-environment.in
+++ b/scripts/build-setup-environment.in
@@ -16,6 +16,18 @@ if [ -z "$OEINIT" ]; then
     echo >&2 "oe-init-build-env not found in @OEROOT@"
     false
 else
+    if [ -d "@OEROOT@/../pyrex" ]; then
+        echo >&2 "Using pyrex to run builds in a docker container."
+
+        PYREX_CONFIG_BIND="@OEROOT@/.."
+        BITBAKEDIR=@OEROOT@/../bitbake
+        OEROOT=@OEROOT@/../oe-core
+        PYREX_OEINIT="$OEINIT"
+        PYREX_ROOT="@OEROOT@/../pyrex"
+        PYREXCONFFILE="$BUILDDIR/conf/pyrex.ini"
+        OEINIT="$PYREX_ROOT/pyrex-init-build-env"
+    fi
+
     . "$OEINIT" "$BUILDDIR" "@BITBAKEDIR@"
     export BB_ENV_PASSTHROUGH_ADDITIONS="$BB_ENV_PASSTHROUGH_ADDITIONS GIT_SSL_CAINFO SALT_LICENSE_SERVER SALT_EXCLUDE_LICENSES SALT_INCLUDE_LICENSES SALT_LOGGING_DIR SALT_PKGINFO_FILE SALT_LICENSE_SOURCE WSL_INTEROP"
     unset TEMPLATECONF OEINIT

--- a/scripts/setup-flex-builddir
+++ b/scripts/setup-flex-builddir
@@ -318,6 +318,27 @@ setup_builddir () {
         fi
     fi
 
+    if [ -d "$FLEXDIR/pyrex" ]; then
+        if [ -z "$PYREXCONFFILE" ]; then
+            PYREXCONFFILE="$BUILDDIR/conf/pyrex.ini"
+        fi
+        if [ ! -e "$PYREXCONFFILE" ]; then
+            "$FLEXDIR/pyrex/mkconfig" | grep -v '^\[run\]' >"$PYREXCONFFILE"
+            cat >>"$PYREXCONFFILE" <<END
+[run]
+bind =
+    \${env:PYREX_BIND}
+    \${env:HOME}/.ssh,readonly
+    \${env:HOME}/.netrc,optional,readonly
+    \${env:HOME}/.gitconfig,optional,readonly
+    \${env:HOME}/.config/git,optional,readonly
+END
+
+            echo "You had no pyrex.ini file. This configuration file has therefore been"
+            echo "created for you with some default values."
+        fi
+    fi
+
     if [ -d "$FLEXDIR/bitbake" ]; then
         BITBAKEDIR="$FLEXDIR/bitbake"
     else


### PR DESCRIPTION
This is intended not for the customer as much as for internal engineers to more easily run their Linux bitbake builds in docker containers. With this:

```
git clone https://github.com/garmin/pyrex
cd build
. ./setup-environment
```

Then all your bitbake commands will automatically be run in a docker container, not natively, making it largely transparent, and enabling use of your existing tooling on the host otherwise.