### PR TITLE
sokol-flex-distro: improve layer by separating user and image features 

### DIFF
--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -339,6 +339,9 @@ include conf/distro/include/flex-security.conf
 # SWUpdate configuration.
 include conf/distro/include/flex-swupdate.conf
 
+# iot-lite configuration.
+include conf/distro/include/flex-iot-lite.conf
+
 # MCF configuration
 include conf/distro/include/flex-mcf.conf
 
@@ -347,3 +350,6 @@ INITRAMFS_IMAGE ?= "flex-initramfs-image"
 INITRAMFS_IMAGE_BUNDLE ?= "${@bb.utils.contains('KERNEL_IMAGETYPES', 'fitImage', '', '1', d)}"
 ## }}}1
 # vim: set fdm=marker fdl=0 :
+
+# We have it here because we use upstream virtualization layer without any changes
+EXTRA_IMAGE_FEATURES += "${@bb.utils.contains('DISTRO_FEATURES', 'virtualization', 'virtualization', '', d)}"

--- a/meta-sokol-flex-distro/dynamic-layers/virtualization-layer/conf/local.conf.append
+++ b/meta-sokol-flex-distro/dynamic-layers/virtualization-layer/conf/local.conf.append
@@ -1,3 +1,2 @@
 # Comment out the following to disable virtualization support
 USER_FEATURES += "virtualization"
-EXTRA_IMAGE_FEATURES += "${@bb.utils.contains('DISTRO_FEATURES', 'virtualization', 'virtualization', '', d)}"


### PR DESCRIPTION

IMAGE_FEATURES in local.conf.append files are removed to distro configuration to separate
them from USER_FEATURES

local.conf.append: removal of EXTRA_IMAGE_FEATURES from feature layer

sokol-flex.conf: Addition of EXTRA_IMAGE_FEATURES to distro layer, inclusion of distro configuration path for iot feature

JIRA: SB-20851

Signed-off-by: Aoun Ahmed <aoun_ahmad@mentor.com>

