### PR TITLE
image-root-password.bbclass: fix default empty root password login

### DIFF
--- a/meta-sokol-flex-common/classes/image-root-password.bbclass
+++ b/meta-sokol-flex-common/classes/image-root-password.bbclass
@@ -31,7 +31,7 @@ def encrypt_root_pw(d):
     prefix = '$6$'
 
     password = d.getVar('ROOT_PASSWORD')
-    if any(password == pattern for pattern in [ 'None', '0', '*' ]):
+    if any(password == pattern for pattern in [ '', '0', '*' ]):
         return ''
 
     salt = base64.b64encode(os.urandom(8))


### PR DESCRIPTION
The root user login on development-image and production-image does not work when ROOT_PASSWORD is not set i.e. by default. This is due to a bug in the image-root-password.bbclass function encrypt_root_pw that does an invalid comparison of the password string with 'None'. It should rather compare it with an empty string as that is the default state of the ROOT_PASSWORD var.
Otherwise, the ACTUAL_ROOT_PASSWORD evaluates to "'*0'" which is not a proper encrypted password.

JIRA: SB-20967

Signed-off-by: Arsalan H. Awan <Arsalan_Awan@mentor.com>