### PR TITLE
flex-checkout: default the git init branch to main, not $branch

### DIFF
--- a/scripts/release/flex-checkout
+++ b/scripts/release/flex-checkout
@@ -263,9 +263,8 @@ done | (
 ) | cut -d"$(printf '\t')" -f2 | \
     while read -r manifest; do
         cat "$manifest" | while read -r checkout_path commit remotes; do
-            branch="$(basename "${manifest%.manifest}")"
             if [ ! -d "$checkout_path/.git" ]; then
-                git init -b "$branch" "$checkout_path"
+                git init -b main "$checkout_path"
             fi
 
             cd "$checkout_path"
@@ -280,6 +279,7 @@ done | (
                 echo "$commit" >.git/shallow
             fi
 
+            branch="$(basename "${manifest%.manifest}")"
             if ! git rev-parse -q --verify "refs/heads/$branch" >/dev/null; then
                 git update-ref "refs/heads/$branch" "$commit"
             fi


### PR DESCRIPTION
By prematurely setting our branch, the later logic to check out that
branch does nothing, as we're already on it. The problem is we never
actually did a checkout, so no files exist. Explicitly specify a default
branch which does not match our own to avoid skipping the later
checkout.

JIRA: SB-21205

Signed-off-by: Christopher Larson <chris_larson@mentor.com>
