### PR TITLE
flex-checkout: fix for 'sokol-flex' and +snapshot

### DIFF
--- a/scripts/release/flex-checkout
+++ b/scripts/release/flex-checkout
@@ -50,7 +50,7 @@ verify_machine () {
 set_machine () {
     workspace="$1"
     manifest_name=$(basename "$2")
-    manifest_machine=$(echo "$manifest_name" | cut -d'-' -f3- | cut -d'.' -f1)
+    manifest_machine=$(echo "$manifest_name" | sed -e 's/+snapshot-[0-9.]*//' | cut -d'-' -f4- | cut -d'.' -f1)
     echo "$manifest_machine" > "$workspace/.machine"
 }
 


### PR DESCRIPTION
Due to the use of '-' as the separator in our manifest filenames, we
have to know precisely how to get the machine name back out of it, which
means the number of dashes in the DISTRO is a factor. Now that we're
`sokol-flex` rather than `mel`, we need to adjust the cut to the 4th,
not 3rd dash, and also strip off the +snapshot- suffix.

JIRA: SB-21211

Signed-off-by: Christopher Larson <chris_larson@mentor.com>
