### PR TITLE
sokol-flex: change version from 13.0+snapshot-${DATE} to 13

### DIFF
--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -14,7 +14,7 @@ SUPPORT_URL = "https://support.sw.siemens.com/"
 BUG_REPORT_URL = "https://support.sw.siemens.com/"
 
 # Distro and release versioning
-DISTRO_VERSION = "13.0+snapshot-${DATE}"
+DISTRO_VERSION = "13"
 ARCHIVE_RELEASE_VERSION = "${DISTRO_VERSION}.${BSP_VERSION}.${PATCH_VERSION}"
 PDK_LICENSE_VERSION_DATE = "20181206"
 


### PR DESCRIPTION
0.0 will still be appended for bsp and patch versions, resulting in a final complete version string of 13.0.0 as expected. SDKs have their timestamps appended separately, so that isn't affected by this.

JIRA: SB-21242

Signed-off-by: Christopher Larson <chris_larson@mentor.com>
