### PR TITLE
toolchain-shar-extract.sh: add -v argument to show sdk version

### DIFF
--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -196,7 +196,7 @@ INHERIT += "required_toolchain_config"
 # Use our toolchain relocation scripts
 INHERIT += "${@bb.utils.contains('BBFILE_COLLECTIONS', 'sokol-flex-staging', 'toolchain_ship_relocate_sdk', '', d)}"
 TOOLCHAIN_SHAR_REL_TMPL = "${LAYERDIR_sokol-flex-staging}/files/toolchain-shar-relocate.sh"
-TOOLCHAIN_EXT_REL_TMPL = "${LAYERDIR_sokol-flex-staging}/files/toolchain-shar-extract.sh"
+TOOLCHAIN_SHAR_EXT_TMPL = "${LAYERDIR_sokol-flex-staging}/files/toolchain-shar-extract.sh"
 RELOCATE_SDK_SH ?= "${LAYERDIR_sokol-flex-staging}/files/relocate_sdk.sh"
 ## }}}1
 ## Preferences & Package Selection {{{1

--- a/meta-sokol-flex-staging/files/toolchain-shar-extract.sh
+++ b/meta-sokol-flex-staging/files/toolchain-shar-extract.sh
@@ -69,7 +69,8 @@ savescripts=0
 verbose=0
 publish=0
 listcontents=0
-while getopts ":yd:npDRSl" OPT; do
+showversion=0
+while getopts ":yd:npDRSlv" OPT; do
 	case $OPT in
 	y)
 		answer="Y"
@@ -97,6 +98,9 @@ while getopts ":yd:npDRSl" OPT; do
 	l)
 		listcontents=1
 		;;
+	v)
+		showversion=1
+		;;
 	*)
 		echo "Usage: $(basename $0) [-y] [-d <dir>]"
 		echo "  -y         Automatic yes to all prompts"
@@ -109,10 +113,16 @@ while getopts ":yd:npDRSl" OPT; do
 		echo "  -R         Do not relocate executables"
 		echo "  -D         use set -x to see what is going on"
 		echo "  -l         list files that will be extracted"
+		echo "  -v         Display version"
 		exit 1
 		;;
 	esac
 done
+
+if [ "$showversion" -eq 1 ]; then
+	echo "@SDK_VERSION@"
+	exit
+fi
 
 payload_offset=$(($(grep -na -m1 "^MARKER:$" $0|cut -d':' -f1) + 1))
 if [ "$listcontents" = "1" ] ; then


### PR DESCRIPTION
Specifically, this shows the value of the `SDK_VERSION` variable.

JIRA: SB-20916

For example:
```
$ ./tmp/deploy/sdk/sdk-x86_64-sokol-flex-13.0.202212272016-development-image-icicle-kit-es-flex.sh -v
13.0.202212272016
```