### PR TITLE
sokol-flex: Add Sokol Omni as supported distro

### DIFF
--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -68,6 +68,7 @@ SANITY_TESTED_DISTROS = "\
     ubuntu-22.04 \n\
     rhel*-9* \n \
     redhatenterprise*-9* \n \
+    sokolomnios-3.1 \n\
 "
 
 # Sane default append for the kernel cmdline (not used by all BSPs)


### PR DESCRIPTION
Add Sokol Omni as a tested distro as it will be used in WSL2

JIRA: SB-21031

Signed-off-by: Arslan Ahmad <arslan_ahmad@mentor.com>