### PR TITLE
rebranding: removed mel occurences with flex

### DIFF
--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -256,7 +256,7 @@ SDKPATHINSTALL = "~/${DISTRO}/sdk/${SDK_VERSION}/${IMAGE_BASENAME}-${MACHINE}"
 
 # Set the SDK title. SDK_VERSION is left out, as it's explicitly shown in the installer
 SDK_TITLE ?= "${DISTRO_NAME} ${IMAGE_BASENAME} SDK for ${MACHINE}"
-SDK_TITLE:task-populate-sdk-ext:mel = "${DISTRO_NAME} ${IMAGE_BASENAME} Extensible SDK for ${MACHINE}"
+SDK_TITLE:task-populate-sdk-ext:flex = "${DISTRO_NAME} ${IMAGE_BASENAME} Extensible SDK for ${MACHINE}"
 
 # Define a common identifier for a unique SDK, to be set in CodeBench metadata
 SDK_IDENTIFIER ?= "${SDKMACHINE}-${IMAGE_BASENAME}-${MACHINE}-${SDK_VERSION}"

--- a/scripts/capdebuginfo
+++ b/scripts/capdebuginfo
@@ -174,8 +174,8 @@ get_flexinstallinfo () {
    local __outputdir="${1}"
    local __output="${1}/host/${2}"
    
-   if [ -d "${HOMEDIR}"/.mentor ]; then
-      cp -a "${HOMEDIR}"/.mentor/.registry "${__outputdir}"/host/mentor-registry
+   if [ -d "${HOMEDIR}"/.siemens ]; then
+      cp -a "${HOMEDIR}"/.siemens/.registry "${__outputdir}"/host/siemens-registry
    else
       echo -en "\\nNo Sokol Flex OS install info found!\\n" >> ${__output}
    fi


### PR DESCRIPTION
For re-branding requirements we need to remove all the possible occurrences of string mel or mentor with flex. Most of such files have been renamed, and occurrences of such strings.

JIRA ID: SB-21223

Signed-off-by: Akif Tariq <akif.tariq@siemens.com>