### PR TITLE
Update toolchain-shar scripts from oe-core

### DIFF
--- a/meta-sokol-flex-staging/files/toolchain-shar-extract.sh
+++ b/meta-sokol-flex-staging/files/toolchain-shar-extract.sh
@@ -255,21 +255,6 @@ fi
 echo "done"
 
 printf "Setting it up..."
-# fix environment paths
-real_env_setup_script=""
-for env_setup_script in `ls $target_sdk_dir/environment-setup-*`; do
-	if grep -q 'OECORE_NATIVE_SYSROOT=' $env_setup_script; then
-		# Handle custom env setup scripts that are only named
-		# environment-setup-* so that they have relocation
-		# applied - what we want beyond here is the main one
-		# rather than the one that simply sorts last
-		real_env_setup_script="$env_setup_script"
-	fi
-	$SUDO_EXEC sed -e "s:@SDKPATH@:$target_sdk_dir:g" -i $env_setup_script
-done
-if [ -n "$real_env_setup_script" ] ; then
-	env_setup_script="$real_env_setup_script"
-fi
 
 @SDK_POST_INSTALL_COMMAND@
 
@@ -277,14 +262,6 @@ fi
 # if he/she wants another location for the sdk
 if [ $savescripts = 0 ] ; then
 	$SUDO_EXEC rm -f ${env_setup_script%/*}/relocate_sdk.py ${env_setup_script%/*}/relocate_sdk.sh
-fi
-
-# Execute post-relocation script
-post_relocate="$target_sdk_dir/post-relocate-setup.sh"
-if [ -e "$post_relocate" ]; then
-	$SUDO_EXEC sed -e "s:@SDKPATH@:$target_sdk_dir:g" -i $post_relocate
-	$SUDO_EXEC /bin/sh $post_relocate "$target_sdk_dir" "@SDKPATH@"
-	$SUDO_EXEC rm -f $post_relocate
 fi
 
 echo "SDK has been successfully set up and is ready to be used."

--- a/meta-sokol-flex-staging/files/toolchain-shar-extract.sh
+++ b/meta-sokol-flex-staging/files/toolchain-shar-extract.sh
@@ -67,7 +67,8 @@ savescripts=0
 verbose=0
 publish=0
 listcontents=0
-while getopts ":yd:npDRSl" OPT; do
+showversion=0
+while getopts ":yd:npDRSlv" OPT; do
 	case $OPT in
 	y)
 		answer="Y"
@@ -95,6 +96,9 @@ while getopts ":yd:npDRSl" OPT; do
 	l)
 		listcontents=1
 		;;
+	v)
+		showversion=1
+		;;
 	*)
 		echo "Usage: $(basename "$0") [-y] [-d <dir>]"
 		echo "  -y         Automatic yes to all prompts"
@@ -107,10 +111,16 @@ while getopts ":yd:npDRSl" OPT; do
 		echo "  -R         Do not relocate executables"
 		echo "  -D         use set -x to see what is going on"
 		echo "  -l         list files that will be extracted"
+		echo "  -v         Display version"
 		exit 1
 		;;
 	esac
 done
+
+if [ "$showversion" -eq 1 ]; then
+	echo "@SDK_VERSION@"
+	exit
+fi
 
 payload_offset=$(($(grep -na -m1 "^MARKER:$" "$0"|cut -d':' -f1) + 1))
 if [ "$listcontents" = "1" ] ; then


### PR DESCRIPTION
I actually revert the scripts to their pristine states from current oe-core, then re-apply our fixes on top of them. This serves to clarify our history and ease future updates, as this wasn't done consistently when these were originally added. This does mean that the intermediate states here would not be functional, the entirety is required to have a fully functional setup at this time. Most of the commits to relocate_sdk.sh were necessary to allow for it to be run standalone rather than embedded in the shar script.

Thinking further, I don't intend to keep the highly granular history. I'll archive it for use with upstream submission, but it's excessive for our ongoing history.

## Testing

- [x] Build the SDK
- [x] Install the SDK and test it
- [x] Install the SDK passing `-RS`, verify it was relocated but executables were not, and verify we can run `relocate_sdk.sh` afterward to relocate it, and test it
- [ ] Install the SDK passing `-S`, move it, and re-relocate it and test it
- [ ] Run the `oe-selftest` tests against the SDK

## Expected Result

### Installation

```
Sokol Flex OS development-image SDK for icicle-kit-es-flex installer version 13.202301061915                                                                                   
============================================================================================                                                                                   
You are about to install the SDK to "/mel/kergoth/mel/ginkgo/SB-21318/build/sdk". Proceed [Y/n]? Y                                                                             
Extracting SDK.................................................................................................................................................................
...............................................................................................................................................................................
.................................................................................................................................................done                          
Setting it up...done                                                                                                                                                           
SDK has been successfully set up and is ready to be used.                                                                                                                      
Each time you wish to use the SDK in a new shell session, you need to source the environment setup script e.g.
 $ . /mel/kergoth/mel/ginkgo/SB-21318/build/sdk/environment-setup-riscv64-oe-linux
```

### Testing

```
$ rm -f hello; bash -c '. ./sdk/environment-setup* && eval $CC $CFLAGS $LDFLAGS hello.c -o hello && file hello'
hello: ELF 64-bit LSB executable, UCB RISC-V, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-riscv64-lp64d.so.1, BuildID[sha1]=565274e4ac70fd045792336bc992cc37b7bc199a, for GNU/Linux 4.15.0, with debug_info, not stripped
```

## Testing Notes

The first version of the SDK installed after making changes showed a concatenation of the line coming from meta-sourcery and the "Setting it up..." message from `toolchain-shar-extract.sh`, hence adding the meta-sourcery commit, and moving the echo of done into `toolchain-shar-extract.sh` where it belongs.

I realized there's a bug in re-relocation in that the relocate_sdk.py isn't having its `old_prefix` updated during relocation, so went ahead and fixed that too.

I also noticed that `-R` on the SDK installer doesn't really behave as expected right now, as it's run whether `-R` is passed or not, so it can't be conditional upon `$relocate` the way it really should be. Changing it to be conditional wouldn't be 100% identical to original behavior either, though, since `-R` is supposed to only affect relocation of executables, not replacement of install paths. I'm not sure if we care about the functionality of this argument, but I was explicitly testing it to make sure after-the-fact relocation was working fully. I think the current behavior may be okay, in that it's arguable whether an SDK with its included toolchain entirely unrelocated would be any good to anyone anyway.