### PR TITLE
sokol-flex-distro: relocate APPEND to flex-bsp-common

### DIFF
--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -70,18 +70,6 @@ SANITY_TESTED_DISTROS = "\
     redhatenterprise*-9* \n \
 "
 
-# Sane default append for the kernel cmdline (not used by all BSPs)
-# TODO: rename APPEND to something more appropriate
-APPEND ?= "${APPEND_SERIAL} console=tty0 ${APPEND_SPLASH}"
-
-APPEND_SPLASH = "${@'quiet splash' if '${SPLASH}' else ''}"
-
-APPEND_SERIAL = "${@'console=${CMD_SERIAL_CONSOLE}' if '${SERIAL_CONSOLE}' else ''}"
-CMD_SERIAL_CONSOLE ?= "${@','.join(reversed('${SERIAL_CONSOLE}'.split()))}"
-
-# Not in APPEND by default, but can be added to it as needed
-APPEND_KGDBOC = "kgdbwait kgdboc=${CMD_SERIAL_CONSOLE}"
-
 # Splash screen
 SPLASH:sokol-flex ?= "psplash"
 


### PR DESCRIPTION
Relocate $APPEND and related variables to flex-bsp-common so that
all boot related params for uboot and grub are unified and edited
at one place.

sokol-flex-conf: removal of $APPEND and related variables so we can
shift it to flex-bsp-common.inc.

JIRA ID: SB-20844

Signed-off-by: Aoun Ahmed <aoun.ahmad.ext@siemens.com>