### PR TITLE
sokol-flex-distro: rename iot-lite to iot

### DIFF
--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -336,8 +336,8 @@ include conf/distro/include/flex-security.conf
 # SWUpdate configuration.
 include conf/distro/include/flex-swupdate.conf
 
-# iot-lite configuration.
-include conf/distro/include/flex-iot-lite.conf
+# iot configuration.
+include conf/distro/include/flex-iot.conf
 
 # MCF configuration
 include conf/distro/include/flex-mcf.conf


### PR DESCRIPTION
iot-lite layer has been rename to iot.
Update all instances

JIRA: SB-21351

Signed-off-by: Arslan Ahmad <arslan_ahmad@mentor.com>