### PR TITLE
sokol-flex: gather info to diagnose licensing network issues

### DIFF
--- a/meta-sokol-flex-common/classes/taskenvlog.bbclass
+++ b/meta-sokol-flex-common/classes/taskenvlog.bbclass
@@ -1,0 +1,28 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# SPDX-License-Identifier: MIT
+# ---------------------------------------------------------------------------------------------------------------------
+
+# Log the values of specified variables when starting tasks as debug messages
+TASK_ENV_LOG_VARS ?= ""
+
+python log_task_env() {
+    import re
+
+    # Warning: copied from ConfHandler
+    flagpattern = re.compile(r'^(?P<var>[a-zA-Z0-9\-_+.${}/~:]+?)(\[(?P<flag>[a-zA-Z0-9\-_+.]+)\])?$', re.X)
+
+    for k in d.getVar('TASK_ENV_LOG_VARS').split():
+        m = flagpattern.match(k)
+        if not m:
+            bb.warn('Unexpected value in TASK_ENV_LOG_VARS: %s' % k)
+            continue
+
+        if m.group('flag'):
+            v = d.getVarFlag(m.group('var'), m.group('flag'), expand=True)
+        else:
+            v = d.getVar(k)
+
+        bb.debug(1, '%s %s: Environment: %s="%s"' % (e._package, e._task, k, v or ''))
+}
+log_task_env[eventmask] = "bb.build.TaskStarted"
+addhandler log_task_env

--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -221,6 +221,11 @@ FEATURE_PACKAGES_multilib-runtime ?= "${@d.getVar('MULTILIB_RUNTIME_FEATURE_PACK
 DISTRO_EXTRA_RRECOMMENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', '', 'nss-myhostname', d)}"
 ## }}}1
 ## Workarounds & Overrides {{{1
+# Include information needed to diagnose licensing issues due to network access
+BUILDCFG_VARS += "SOURCERY_LICENSE_NETWORK_TASKS"
+INHERIT += "taskenvlog"
+TASK_ENV_LOG_VARS += "${BB_RUNTASK}[network]"
+
 # Re-export and exclude from checksums
 export WSL_INTEROP
 BB_BASEHASH_IGNORE_VARS:append = " WSL_INTEROP"


### PR DESCRIPTION
- Add the value of SOURCERY_LICENSE_NETWORK_TASKS to the Build
  Configuration header at the start of a bitbake build.
- Add debug messages to task logs with the value of the task's `network`
  flag before running the task.

Example addition to Build Configuration header:

    SOURCERY_LICENSE_NETWORK_TASKS = "    do_configure     do_compile     do_compile_kernelmodules     do_install     do_bundle_initramfs     do_configure_ptest     do_compile_ptest     do_install_ptest "

Example addition to a task log file:

    DEBUG: glibc-2.35-r0 do_configure: Environment: do_configure[network]="1"

JIRA: SB-21627
