### PR TITLE
sokol-flex, archive-release: reset SCRIPTS_VERSION to 0

### DIFF
--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -19,7 +19,7 @@ ARCHIVE_RELEASE_VERSION = "${DISTRO_VERSION}.${BSP_VERSION}.${PATCH_VERSION}"
 PDK_LICENSE_VERSION_DATE = "20181206"
 
 # Version of the scripts artifact, including setup-flex
-SCRIPTS_VERSION ?= "1"
+SCRIPTS_VERSION ?= "0"
 
 # Default values for BSP and PATCH version, to be redefined in other layers
 BSP_VERSION ?= "0"

--- a/meta-sokol-flex-support/recipes-core/meta/archive-release.bb
+++ b/meta-sokol-flex-support/recipes-core/meta/archive-release.bb
@@ -22,7 +22,7 @@ BINARY_ARTIFACTS_COMPRESSION[doc] = "Compression type for images and downloads a
 ARCHIVE_RELEASE_VERSION ?= "${DISTRO_VERSION}"
 MANIFEST_NAME ?= "${DISTRO}-${ARCHIVE_RELEASE_VERSION}-${MACHINE}"
 EXTRA_MANIFEST_NAME ?= "${DISTRO}-${ARCHIVE_RELEASE_VERSION}"
-SCRIPTS_VERSION ?= "1"
+SCRIPTS_VERSION ?= "0"
 SCRIPTS_ARTIFACT_NAME ?= "${DISTRO}-scripts-${DISTRO_VERSION}.${SCRIPTS_VERSION}"
 
 # Don't allow git to chdir up past our workspace to avoid redistributing the wrong repository


### PR DESCRIPTION
This should start at 0 as the other version components do, for consistency.

JIRA: SB-21762