### PR TITLE
setup-environment: fix argument handling for args >9

### DIFF
--- a/scripts/setup-flex-builddir
+++ b/scripts/setup-flex-builddir
@@ -335,8 +335,8 @@ setup_builddir () {
               -e "s#@TEMPLATECONF@#$TEMPLATECONF#g" >"$BUILDDIR/setup-environment"
 }
 
-scriptsdir="$(cd $(dirname $0) && pwd)"
-scriptsdir="$(abspath $scriptsdir)"
+scriptsdir="$(cd "$(dirname "$0")" && pwd)"
+scriptsdir="$(abspath "$scriptsdir")"
 layerdir="${scriptsdir%/*}"
 
 tmpdir="$(mktemp -d -t "${0##*/}.XXXXX")" || exit 1

--- a/setup-environment
+++ b/setup-environment
@@ -38,10 +38,10 @@ else
     fi
 
     for i in $(seq $#); do
-        setup_flex_arg="$(eval printf "%s" "\$$i")"
+        setup_flex_arg="$(eval printf "%s" "\${$i}")"
         case "$setup_flex_arg" in
             -b)
-                BUILDDIR="$(eval printf "%s" "\$$((i + 1))")"
+                BUILDDIR="$(eval printf "%s" "\${$((i + 1))}")"
                 if [ -z "$BUILDDIR" ]; then
                     echo >&2 "-b requires an argument"
                 fi


### PR DESCRIPTION
This script iterates through the arguments solely to get the correct `$BUILDDIR`, but doesn't have full fledged option parsing since it's actually a light wrapper around setup-flex-builddir.  During this iteration, it seems '$10' gets expanded as '$1' followed by a 0, which isn't what we're looking for here, so use '${}' syntax instead.

JIRA: SB-21796