### PR TITLE
setup scripts: install python3 setuptools package

### DIFF
--- a/scripts/setup-debian
+++ b/scripts/setup-debian
@@ -34,6 +34,7 @@ set -- \
     make \
     patch \
     python3 \
+    python3-setuptools \
     python3-distutils \
     rsync \
     wget \

--- a/scripts/setup-rh
+++ b/scripts/setup-rh
@@ -10,6 +10,7 @@
 # kind, whether express or implied.
 
 packages="python39 \
+          python39-setuptools \
           patch diffstat git bzip2 tar \
           gzip gawk chrpath wget cpio perl file which \
           make gcc gcc-c++ rsync rpcgen \

--- a/scripts/setup-ubuntu
+++ b/scripts/setup-ubuntu
@@ -21,7 +21,7 @@ else
     SUDO=
 fi
 
-PKGS="$PKGS ubuntu-minimal ubuntu-standard make gcc g++ patch diffstat texinfo texi2html cvs subversion bzip2 tar gzip gawk chrpath libncurses5-dev git-core lsb-release python3 xvfb x11-utils rsync zstd liblz4-tool"
+PKGS="$PKGS ubuntu-minimal ubuntu-standard make gcc g++ patch diffstat texinfo texi2html cvs subversion bzip2 tar gzip gawk chrpath libncurses5-dev git-core lsb-release python3 python3-setuptools xvfb x11-utils rsync zstd liblz4-tool"
 
 # These are needed for the qemu-native build
 PKGS="$PKGS libgl1-mesa-dev libglu1-mesa-dev libsdl1.2-dev"


### PR DESCRIPTION
The recipetool utility requires the python's setuptools package. The setup scripts have been updated to install the python's setuptools package.

JIRA: SB-21904