### PR TITLE
conf-notes.txt: remove qemu lines and format

### DIFF
--- a/conf/conf-notes.txt
+++ b/conf/conf-notes.txt
@@ -5,6 +5,3 @@ Common targets are:
 
 production-image requires that the ROOT_PASSWORD variable be set. See
 conf/local.conf for details.
-
-For qemu machines, you can also run the generated qemu images with a command
-like 'runqemu qemux86'.

--- a/conf/conf-notes.txt
+++ b/conf/conf-notes.txt
@@ -1,4 +1,5 @@
-Common targets are:
+
+Common bitbake targets are:
 
     development-image
     production-image


### PR DESCRIPTION
Changes this:
```
Determining layers to include for MACHINE 'icicle-kit-es-flex'...core,flex-bsp-common,flex-bsp-polarfire-icicle-kit,flex-polarfire-common,flex-swupdate,flex-user-examples,meta-polarfire-soc-yocto-bsp,openembedded-layer,riscv-layer,sokol-flex-common,sokol-flex-distro,sokol-flex-support,swupdate
Checking for optional layers...
Common targets are:

    development-image
    production-image

production-image requires that the ROOT_PASSWORD variable be set. See
conf/local.conf for details.

For qemu machines, you can also run the generated qemu images with a command
like 'runqemu qemux86'.
```

To this:
```
Determining layers to include for MACHINE 'icicle-kit-es-flex'...core,flex-bsp-common,flex-bsp-polarfire-icicle-kit,flex-polarfire-common,flex-swupdate,flex-user-examples,meta-polarfire-soc-yocto-bsp,openembedded-layer,riscv-layer,sokol-flex-common,sokol-flex-distro,sokol-flex-support,swupdate
Checking for optional layers...

Common bitbake targets are:

    development-image
    production-image

production-image requires that the ROOT_PASSWORD variable be set. See
conf/local.conf for details.
```