### PR TITLE
relocate_sdk.sh: find ld-linux only at toplevel

### DIFF
--- a/meta-sokol-flex-staging/files/relocate_sdk.sh
+++ b/meta-sokol-flex-staging/files/relocate_sdk.sh
@@ -43,7 +43,7 @@ if [ -e "$native_sysroot/lib" ]; then
         exit 1
     fi
 
-    dl_path=$(find $native_sysroot/lib -name "ld-linux*")
+    dl_path=$(find $native_sysroot/lib -mindepth 1 -maxdepth 1 -name "ld-linux*" | head -n 1)
     if [ "$dl_path" = "" ] ; then
             echo "SDK could not be set up. Relocate script unable to find ld-linux.so. Abort!"
             exit 1


### PR DESCRIPTION
Also ensure we only select one.

Without this change, it may select the .debug version of ld-linux in
SDKs which include debug info, which is usual.

JIRA: SB-22047