### PR TITLE
setup scripts: install python3-setuptools package. 

### DIFF
--- a/scripts/setup-rh
+++ b/scripts/setup-rh
@@ -10,7 +10,7 @@
 # kind, whether express or implied.
 
 packages="python39 \
-          python39-setuptools \
+          python3-setuptools \
           patch diffstat git bzip2 tar \
           gzip gawk chrpath wget cpio perl file which \
           make gcc gcc-c++ rsync rpcgen \


### PR DESCRIPTION
    The setuptools package is required by recipetool utility.
    Explicitly installing the setuptool package in setup-rh
    script to fulfil the dependency.

    JIRA: SB-22045

    Signed-off-by: Arsalan Saleem <arsalan_saleem@mentor.com>