### PR TITLE
sokol-flex.conf: add feature support for encrypted-fs

### DIFF
--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -243,6 +243,9 @@ IMAGE_BUILDINFO_VARS ?= "\
     DATETIME \
     IMAGE_BASENAME IMAGE_FEATURES CORE_IMAGE_EXTRA_INSTALL \
 "
+
+# Encrypted FS
+EXTRA_IMAGE_FEATURES:append:feature-encrypted-fs = " encrypted-fs"
 ## }}}1
 ## SDK & Application Development Environment {{{1
 # Use DEPLOY_DIR_ naming for consistency


### PR DESCRIPTION
Support for encrypted-fs has been implemented for imx in meta-flex-ref-bsps repository. This change enables the encrypted-fs feature when it is enabled in main
local.conf

JIRA-ID: SB-21384