### PR TITLE
busybox: enable base64 utility

### DIFF
--- a/meta-sokol-flex-distro/recipes-core/busybox/busybox/base64.cfg
+++ b/meta-sokol-flex-distro/recipes-core/busybox/busybox/base64.cfg
@@ -1,0 +1,2 @@
+# base64 utility is required by Qt creator IDE for Device Test
+CONFIG_BASE64=y

--- a/meta-sokol-flex-distro/recipes-core/busybox/busybox_%.bbappend
+++ b/meta-sokol-flex-distro/recipes-core/busybox/busybox_%.bbappend
@@ -11,4 +11,5 @@ SRC_URI:append:sokol-flex = "\
     file://fancy-head.cfg \
 	file://pidof.cfg \
 	file://top.cfg \
+    file://base64.cfg \
 "


### PR DESCRIPTION
Qt creator IDE checks target connectivity and presence of some utilities on the target rootfs to perform device test. The test fails if base64 utility is not found. To address this, enable base64 utility by default for our distro using CONFIG_BASE64 config fragment.

JIRA-ID: SB-21059