### PR TITLE
udev: fix for systemd mounting timeout issue for dmsetup encrypted pa…

### DIFF
--- a/meta-sokol-flex-distro/dynamic-layers/openembedded-layer/recipes-support/lvm2/lvm2-flex.inc
+++ b/meta-sokol-flex-distro/dynamic-layers/openembedded-layer/recipes-support/lvm2/lvm2-flex.inc
@@ -1,6 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/lvm2:"
 
 SRC_URI:append = " file://lvm2-flex.service"
+SRC_URI:append = " file://09-dm_hack.rules"
 
 PACKAGES += "${PN}-flex"
 RDEPENDS:${PN} += "${PN}-flex"
@@ -14,4 +15,6 @@ do_install:append() {
     if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
         install -m 0644 ${WORKDIR}/${SYSTEMD_SERVICE:${PN}-flex} ${D}${systemd_system_unitdir}/
     fi
+    install -m 0755 -d ${D}${sysconfdir}/udev/rules.d/
+    install -m 0644 ${WORKDIR}/09-dm_hack.rules ${D}${sysconfdir}/udev/rules.d/
 }

--- a/meta-sokol-flex-distro/dynamic-layers/openembedded-layer/recipes-support/lvm2/lvm2/09-dm_hack.rules
+++ b/meta-sokol-flex-distro/dynamic-layers/openembedded-layer/recipes-support/lvm2/lvm2/09-dm_hack.rules
@@ -1,0 +1,8 @@
+KERNEL=="device-mapper", NAME="mapper/control"
+SUBSYSTEM!="block", GOTO="dm_end"
+KERNEL!="dm-[0-9]*", GOTO="dm_end"
+ACTION!="add|change", GOTO="dm_end"
+
+ENV{DM_UDEV_PRIMARY_SOURCE_FLAG}="1"
+
+LABEL="dm_end"


### PR DESCRIPTION
…rtition

Source: https://bugs.gentoo.org/706434

The udev rule 10-dm.rules causes a failure to recognize the uevents leading to timeouts while trying to mount devices activated in initrd without udev.

For detailed explanation:
https://lore.kernel.org/all/CANnVG6mMTcRkWQEEhZSEELfyGHqNkGPx2LmdR9NS+-wkAieGSw@mail.gmail.com/T/

Signed-off-by: Amy Fong [Amy_Fong@mentor.com](mailto:Amy_Fong@mentor.com)