### PR TITLE
curl: remove ssl from packageconfig

### DIFF
--- a/meta-sokol-flex-distro/recipes-support/curl/curl_%.bbappend
+++ b/meta-sokol-flex-distro/recipes-support/curl/curl_%.bbappend
@@ -5,4 +5,3 @@
 # We need openssl support for nativesdk-curl to ensure we can clone https
 # repositories with nativesdk-git.
 DEPENDS:append:class-nativesdk:sokol-flex = " nativesdk-openssl"
-PACKAGECONFIG:append:class-nativesdk:sokol-flex = " ssl"


### PR DESCRIPTION
we need to remove ssl from PACKAGECONFIG to avoid the invalid-packageconfig warning. ssl has been deprecated upstream.

Reference: https://github.com/openembedded/openembedded-core/commit/eef6c45fc6ec0a496791123e8ba2f400a5d9d468

JIRA-ID: SB-21051