### PR TITLE
lvm2-flex.service: replace udev.service with systemd-udevd.service

### DIFF
--- a/meta-sokol-flex-distro/dynamic-layers/openembedded-layer/recipes-support/lvm2/lvm2/lvm2-flex.service
+++ b/meta-sokol-flex-distro/dynamic-layers/openembedded-layer/recipes-support/lvm2/lvm2/lvm2-flex.service
@@ -2,7 +2,7 @@
 Description=Linux Volume Manager
 DefaultDependencies=no
 Before=fsck-root.service local-fs.target 
-After=udev.service
+After=systemd-udevd.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
udev.service does not exist, so there is no point of having it in the `After` unit dependency directive. I think the suitable parameter is `systemd-udevd.service`.

JIRA-ID: SB-22306