### PR TITLE
psplash: disable startup message

### DIFF
--- a/meta-sokol-flex-distro/recipes-core/psplash/psplash_git.bbappend
+++ b/meta-sokol-flex-distro/recipes-core/psplash/psplash_git.bbappend
@@ -14,7 +14,7 @@ SRC_URI:append:sokol-flex = " ${@bb.utils.contains('DISTRO_FEATURES', 'systemd',
 SRC_URI:append:sokol-flex = " file://0001-psplash-config-enable-fullscreen-image.patch \
 		  file://0001-plash-colors.h-color-change.patch \
 		 "
-EXTRA_OECONF:append:sokol-flex = " --disable-progress-bar"
+EXTRA_OECONF:append:sokol-flex = " --disable-progress-bar --disable-startup-msg"
 
 # # Update to latest version of psplash
 # SRCREV:sokol-flex = "5b3c1cc28f5abdc2c33830150b48b278cc4f7bca"


### PR DESCRIPTION
By default startup message is enabled. This draws a stripe close to the bottom of the screen with the background color specified(currently black).

This might not be visible in some cases, where the image is centered and the remaining area is filled with the background color.

Disable startup message to avoid the black rectangle displayed over the psplash image.