### PR TITLE
scripts:setup-env: set LC_CTYPE for bitbake

### DIFF
--- a/scripts/build-setup-environment.in
+++ b/scripts/build-setup-environment.in
@@ -9,6 +9,7 @@ elif [ -n "$ZSH_NAME" ]; then
 else
     BUILDDIR="$(pwd -P)"
 fi
+export LC_CTYPE="en_US.UTF-8"
 export TEMPLATECONF="@TEMPLATECONF@"
 OEINIT="$(find "@OEROOT@" -maxdepth 1 -name \*-init-build-env | head -n 1)"
 if [ -z "$OEINIT" ]; then


### PR DESCRIPTION
With the recent bitbake update, it is utilizing locale.getlocale() and locale.setlocale() from the python locales module. This module has a limitation when the host doesn't have the encoding defined, so e.g. if we have:
```
   $ locale
   ...
   LC_CTYPE="en_IN"
   ...
```
it will not pick the correct encoding:
```
   $ python3
   Python 3.10.6 (main, May 29 2023, 11:10:38) [GCC 11.3.0] on linux
   Type "help", "copyright", "credits" or "license" for more information.
   >>> import locale
   >>> locale.getlocale()
   ('en_IN', 'ISO8859-1')
```
and it will fail:
```
  >>> default_locale = locale.getlocale(locale.LC_CTYPE)
  >>> print(default_locale)
  ('en_IN', 'ISO8859-1')
  >>> locale.setlocale(locale.LC_CTYPE, default_locale)
  Traceback (most recent call last):
    File "<stdin>", line 1, in <module>
    File "/usr/lib/python3.10/locale.py", line 620, in setlocale
      return _setlocale(category, locale)
  locale.Error: unsupported locale setting
```
By setting the locale using LC_CTYPE="en_US.UTF-8", this issue is resolved for bitbake.

JIRA-ID: SB-22332