### PR TITLE
sokol-flex: add multilib prefix to SDK title and identifier

### DIFF
--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -265,7 +265,7 @@ MLPREFIX_SECONDARY = "${@d.getvar('MLPREFIX') if not d.getVar('PN').startswith(d
 
 # Set the SDK title. SDK_VERSION is left out, as it's explicitly shown in the installer
 SDK_TITLE ?= "${DISTRO_NAME} ${MLPREFIX_SECONDARY}${IMAGE_BASENAME} SDK for ${MACHINE}"
-SDK_TITLE:task-populate-sdk-ext:flex = "${DISTRO_NAME} ${MLPREFIX_SECONDARY}${IMAGE_BASENAME} Extensible SDK for ${MACHINE}"
+SDK_TITLE:task-populate-sdk-ext:sokol-flex = "${DISTRO_NAME} ${MLPREFIX_SECONDARY}${IMAGE_BASENAME} Extensible SDK for ${MACHINE}"
 
 # Define a common identifier for a unique SDK, to be set in CodeBench metadata
 SDK_IDENTIFIER ?= "${SDKMACHINE}-${MLPREFIX_SECONDARY}${IMAGE_BASENAME}-${MACHINE}-${SDK_VERSION}"

--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -259,12 +259,16 @@ SDK_NAME_PREFIX = "${DISTRO}"
 SDK_NAME = "${SDK_NAME_PREFIX}-${SDK_VERSION}-${IMAGE_BASENAME}-${MACHINE}"
 SDKPATHINSTALL = "~/${DISTRO}/sdk/${SDK_VERSION}/${IMAGE_BASENAME}-${MACHINE}"
 
+# Current multilib prefix, for non-multilib images. Ex. the lib32
+# environment-setup within a non-lib32 image SDK.
+MLPREFIX_SECONDARY = "${@d.getvar('MLPREFIX') if not d.getVar('PN').startswith(d.getVar('MLPREFIX')) else ''}"
+
 # Set the SDK title. SDK_VERSION is left out, as it's explicitly shown in the installer
-SDK_TITLE ?= "${DISTRO_NAME} ${IMAGE_BASENAME} SDK for ${MACHINE}"
-SDK_TITLE:task-populate-sdk-ext:flex = "${DISTRO_NAME} ${IMAGE_BASENAME} Extensible SDK for ${MACHINE}"
+SDK_TITLE ?= "${DISTRO_NAME} ${MLPREFIX_SECONDARY}${IMAGE_BASENAME} SDK for ${MACHINE}"
+SDK_TITLE:task-populate-sdk-ext:flex = "${DISTRO_NAME} ${MLPREFIX_SECONDARY}${IMAGE_BASENAME} Extensible SDK for ${MACHINE}"
 
 # Define a common identifier for a unique SDK, to be set in CodeBench metadata
-SDK_IDENTIFIER ?= "${SDKMACHINE}-${IMAGE_BASENAME}-${MACHINE}-${SDK_VERSION}"
+SDK_IDENTIFIER ?= "${SDKMACHINE}-${MLPREFIX_SECONDARY}${IMAGE_BASENAME}-${MACHINE}-${SDK_VERSION}"
 
 # As we remove the toolchain from the sdk, naming it 'toolchain' is not
 # accurate, and sdk better describes what it is anyway. We also include


### PR DESCRIPTION
This ensures that these values in the environment-setup files differ
between the base and multilib configurations.

JIRA: SB-22377