### PR TITLE
sokol-flex: fix getvar call which broke sdk builds

### DIFF
--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -261,7 +261,7 @@ SDKPATHINSTALL = "~/${DISTRO}/sdk/${SDK_VERSION}/${IMAGE_BASENAME}-${MACHINE}"
 
 # Current multilib prefix, for non-multilib images. Ex. the lib32
 # environment-setup within a non-lib32 image SDK.
-MLPREFIX_SECONDARY = "${@d.getvar('MLPREFIX') if not d.getVar('PN').startswith(d.getVar('MLPREFIX')) else ''}"
+MLPREFIX_SECONDARY = "${@d.getVar('MLPREFIX') if not d.getVar('PN').startswith(d.getVar('MLPREFIX')) else ''}"
 
 # Set the SDK title. SDK_VERSION is left out, as it's explicitly shown in the installer
 SDK_TITLE ?= "${DISTRO_NAME} ${MLPREFIX_SECONDARY}${IMAGE_BASENAME} SDK for ${MACHINE}"


### PR DESCRIPTION
There was a typo: getvar instead of getVar, which causes the do_populate_sdk
task to fail when these variables are used in our postprocessing functions.

JIRA: SB-22499