### PR TITLE
flex-checkout: re-prompt if .manifest is a zero-byte file

### DIFF
--- a/scripts/release/flex-checkout
+++ b/scripts/release/flex-checkout
@@ -189,7 +189,7 @@ done
 
 manifest="$1"
 if [ -z "$1" ]; then
-    if ! [ -e "$project/.manifest" ]; then
+    if ! [ -s "$project/.manifest" ]; then
         prompt_manifest "$installdir/manifests" "Select manifest" >"$project/.manifest"
         if ! [ -s "$project/.manifest" ]; then
             echo >&2 "Error: no manifest found, please specify"


### PR DESCRIPTION
This occurs if the manifest prompt is interrupted (ex. ^C). By checking
to see if the file exists and is non-empty when determining whether to
prompt, we can avoid this error:

    sed: can't read .info: No such file or directory

JIRA: SB-22545