### PR TITLE
Include multilib library paths in ld.so configuration

### DIFF
--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -231,6 +231,10 @@ do_sca_tracefiles[dirs] =+ "${SCA_SOURCES_DIR}"
 
 # Disable the meta-virtualization layer inclusion warning
 SKIP_META_VIRT_SANITY_CHECK = "1"
+
+# Add all the library paths to ld.so.conf, as the default glibc ldconfig
+# binary does not search for all the multilibs.
+DISTRO_EXTRA_RDEPENDS += "${@bb.utils.contains('BBFILE_COLLECTIONS', 'sokol-flex-staging', multilib_pkg_extend(d, 'ldso-config'), '', d)}"
 ## }}}1
 ## Images {{{1
 # We have it here because we use upstream virtualization layer without any changes

--- a/meta-sokol-flex-staging/recipes-core/glibc/ldso-config.bb
+++ b/meta-sokol-flex-staging/recipes-core/glibc/ldso-config.bb
@@ -1,0 +1,18 @@
+SUMMARY = "ld.so configuration file for the current tuning library paths"
+DESCRIPTION = "${SUMMARY}"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
+INHIBIT_DEFAULT_DEPS = "1"
+
+deltask do_fetch
+deltask do_unpack
+deltask do_patch
+deltask do_configure
+deltask do_compile
+
+do_install () {
+    install -d "${D}${sysconfdir}/ld.so.conf.d"
+    conffile=${D}${sysconfdir}/ld.so.conf.d/${DEFAULTTUNE}.conf
+    echo '${base_libdir}' >>"$conffile"
+    echo '${libdir}' >>"$conffile"
+}


### PR DESCRIPTION
A new recipe installs extra ld.so configuration files for multilib
library paths, to ensure the dynamic linker and ldconfig can find all
the installed libraries.

This gives us correct ldconfig behavior, where `ldconfig -p` lists the
libraries from all multilib library paths.

Before:
```
root@qemuarm64:~# ldconfig -p|grep liblttng-ust-dl
        liblttng-ust-dl.so.1 (libc6,hard-float) => /usr/lib/liblttng-ust-dl.so.1
```

After:
```
root@qemuarm64:~# ldconfig -p|grep liblttng-ust-dl
        liblttng-ust-dl.so.1 (libc6,AArch64) => /usr/lib64/liblttng-ust-dl.so.1
        liblttng-ust-dl.so.1 (libc6,hard-float) => /usr/lib/liblttng-ust-dl.so.1
```

JIRA: SB-25565