### PR TITLE
sokol-flex: add libxcrypt to the multilib runtime packages

### DIFF
--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -207,9 +207,15 @@ FEATURE_PACKAGES_virtualization  ?= "docker-moby python3-docker-compose"
 FEATURE_PACKAGES_codebench-debug ?= "gdbserver strace openssh-sftp-server"
 
 # Baseline runtime for third party multilib executables.
-# libc/libgcc/libstdc++, plus lttng for tracing. Only applies to images
+# Gcc and glibc runtime libraries, plus lttng for tracing. Only applies to images
 # without MLPREFIX set (i.e. development-image, not lib32-development-image).
-MULTILIB_RUNTIME_PACKAGES = "glibc libgcc libstdc++ ${@bb.utils.contains('IMAGE_FEATURES', 'tools-profile', 'lttng-ust', '', d)}"
+MULTILIB_RUNTIME_PACKAGES = "\
+    glibc \
+    libgcc \
+    libstdc++ \
+    libxcrypt \
+    ${@bb.utils.contains('IMAGE_FEATURES', 'tools-profile', 'lttng-ust', '', d)} \
+"
 MULTILIB_RUNTIME_FEATURE_PACKAGES = "${@' '.join(multilib_pkg_extend(d, pkg) for pkg in d.getVar('MULTILIB_RUNTIME_PACKAGES').split())}"
 FEATURE_PACKAGES_multilib-runtime ?= "${@d.getVar('MULTILIB_RUNTIME_FEATURE_PACKAGES') if not d.getVar('MLPREFIX') else ''}"
 


### PR DESCRIPTION
This is expected to already be installed by Sourcery Analyzer.

JIRA: SB-22571