### PR TITLE
Multilib fixes for lttng-tools

### DIFF
--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -214,7 +214,7 @@ MULTILIB_RUNTIME_PACKAGES = "\
     libgcc \
     libstdc++ \
     libxcrypt \
-    ${@bb.utils.contains('IMAGE_FEATURES', 'tools-profile', 'lttng-ust', '', d)} \
+    ${@bb.utils.contains('IMAGE_FEATURES', 'tools-profile', 'lttng-ust lttng-tools', '', d)} \
 "
 MULTILIB_RUNTIME_FEATURE_PACKAGES = "${@' '.join(multilib_pkg_extend(d, pkg) for pkg in d.getVar('MULTILIB_RUNTIME_PACKAGES').split())}"
 FEATURE_PACKAGES_multilib-runtime ?= "${@d.getVar('MULTILIB_RUNTIME_FEATURE_PACKAGES') if not d.getVar('MLPREFIX') else ''}"

--- a/meta-sokol-flex-staging/recipes-kernel/lttng/lttng-tools_%.bbappend
+++ b/meta-sokol-flex-staging/recipes-kernel/lttng/lttng-tools_%.bbappend
@@ -1,0 +1,22 @@
+python () {
+    if not d.getVar('MULTILIBS').strip():
+        return
+
+    variants = (d.getVar("MULTILIB_VARIANTS") or "").split()
+    if 'lib32' in variants:
+        thirty_two = get_multilib_datastore('lib32', d)
+        sixty_four = d
+    elif 'lib64' in variants:
+        thirty_two = d
+        sixty_four = get_multilib_datastore('lib64', d)
+    else:
+        return
+
+    lib64path = sixty_four.getVar('libdir')
+    d.appendVar('EXTRA_OECONF', ' --with-consumerd64-libdir=' + lib64path)
+    d.appendVar('EXTRA_OECONF', ' --with-consumerd64-bin=' + os.path.join(lib64path, 'lttng', 'libexec', 'lttng-consumerd'))
+
+    lib32path = thirty_two.getVar('libdir')
+    d.appendVar('EXTRA_OECONF', ' --with-consumerd32-libdir=' + lib32path)
+    d.appendVar('EXTRA_OECONF', ' --with-consumerd32-bin=' + os.path.join(lib32path, 'lttng', 'libexec', 'lttng-consumerd'))
+}


### PR DESCRIPTION
- lttng-tools: configure paths to 64 and 32 bit consumerd
- sokol-flex: include multilib versions of lttng-tools

JIRA: SB-22623, SB-22565