### PR TITLE
Disable tty1 login for BSPs that choose to do so

### DIFF
--- a/meta-sokol-flex-common/classes/rootfs-disable-tty1-login.bbclass
+++ b/meta-sokol-flex-common/classes/rootfs-disable-tty1-login.bbclass
@@ -1,0 +1,11 @@
+# Disable the login on tty1 if the 'disable-tty1-login' image feature is set
+
+ROOTFS_POSTPROCESS_COMMAND += '${@bb.utils.contains("IMAGE_FEATURES", "disable-tty1-login", "disable_tty1_login; ", "",d)}'
+
+FEATURE_PACKAGES_disable-tty1-login = ""
+
+disable_tty1_login() {
+    if [ -e ${IMAGE_ROOTFS}${root_prefix}/lib/systemd/systemd ]; then
+        systemctl --root="${IMAGE_ROOTFS}" mask getty@tty1.service                                                               
+    fi
+}

--- a/meta-sokol-flex-support/recipes-core/images/flex-image.inc
+++ b/meta-sokol-flex-support/recipes-core/images/flex-image.inc
@@ -11,8 +11,11 @@ IMAGE_INSTALL:append:sokol-flex = " libgcc"
 
 LICENSE = "MIT"
 
-inherit core-image image-buildinfo
+inherit core-image image-buildinfo rootfs-disable-tty1-login
 
 IMAGE_FEATURES:append:sokol-flex = " ${@bb.utils.contains('COMBINED_FEATURES', 'alsa', ' tools-audio', '', d)}"
 IMAGE_INSTALL:append:sokol-flex = " util-linux-mkfs connman"
 IMAGE_INSTALL:append:sokol-flex = " ${@bb.utils.contains_any('IMAGE_FEATURES', ['multimedia', 'graphics'], '${MACHINE_HWCODECS}', '', d)}"
+
+# Allow our BSPs to disable the login on tty1 via MACHINE_FEATURES
+IMAGE_FEATURES:append:sokol-flex = " ${@bb.utils.contains('MACHINE_FEATURES', 'disable-tty1-login', 'disable-tty1-login', '', d)}"


### PR DESCRIPTION
BSPs that want it disabled may add disable-tty1-login to their
MACHINE_FEATURES, which will result in its addition to IMAGE_FEATURES
for flex images, which will disable the login.

JIRA: SB-22595
