### PR TITLE
weston-init: set WAYLAND_DISPLAY in the default shell profile

### DIFF
--- a/meta-sokol-flex-distro/recipes-graphics/wayland/weston-init.bbappend
+++ b/meta-sokol-flex-distro/recipes-graphics/wayland/weston-init.bbappend
@@ -1,0 +1,15 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# SPDX-License-Identifier: MIT
+# ---------------------------------------------------------------------------------------------------------------------
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/weston-init:"
+
+SRC_URI += "file://weston-init.sh"
+
+do_install:append () {
+    # Set WAYLAND_DISPLAY by default for console or ssh users
+    install -d ${D}${sysconfdir}/profile.d/
+    install ${WORKDIR}/weston-init.sh ${D}${sysconfdir}/profile.d/weston-init.sh
+}
+
+FILES:${PN} += "${sysconfdir}/profile.d/weston-init.sh"

--- a/meta-sokol-flex-distro/recipes-graphics/wayland/weston-init/weston-init.sh
+++ b/meta-sokol-flex-distro/recipes-graphics/wayland/weston-init/weston-init.sh
@@ -1,0 +1,1 @@
+export WAYLAND_DISPLAY=/run/wayland-0


### PR DESCRIPTION
Set WAYLAND_DISPLAY by default for console or ssh users so they are able
to run wayland programs more easily. This fixes the ability to run
programs over ssh for Qt Creator, for example.

JIRA: SB-22247