### PR TITLE
lttng-ust: upgrade from 2.13.5 to 2.13.6

### DIFF
--- a/meta-sokol-flex-staging/recipes-kernel/lttng/lttng-ust_2.13.6.bb
+++ b/meta-sokol-flex-staging/recipes-kernel/lttng/lttng-ust_2.13.6.bb
@@ -1,0 +1,15 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# SPDX-License-Identifier: MIT
+# ---------------------------------------------------------------------------------------------------------------------
+
+require recipes-kernel/lttng/lttng-ust_2.13.5.bb
+
+SRC_URI[sha256sum] = "e7e04596dd73ac7aa99e27cd000f949dbb0fed51bd29099f9b08a25c1df0ced5"
+
+# Reset PE due to PV bump, as it's no longer necessary
+PE = ""
+
+# Pull in original patch files from oe-core
+ORIG_FILE := "${@bb.utils.which(d.getVar('BBPATH'), 'recipes-kernel/lttng/lttng-ust_2.13.5.bb')}"
+ORIG_FILE_DIRNAME = "${@os.path.dirname(d.getVar('ORIG_FILE'))}"
+FILESPATH .= ":${ORIG_FILE_DIRNAME}/lttng-ust"


### PR DESCRIPTION
This is necessary to fix a tracing issue where source lookup is disabled
because the"ip" context information is missing.

JIRA: SA-5426