### PR TITLE
Fix lttng-tools multilib issues

### DIFF
--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -220,7 +220,8 @@ MULTILIB_RUNTIME_PACKAGES = "\
     libgcc \
     libstdc++ \
     libxcrypt \
-    ${@bb.utils.contains('IMAGE_FEATURES', 'tools-profile', 'lttng-ust lttng-tools', '', d)} \
+    ${@bb.utils.contains('IMAGE_FEATURES', 'tools-profile', \
+                         'lttng-ust ' + bb.utils.contains('BBFILE_COLLECTIONS', 'sokol-flex-staging', 'lttng-tools-consumerd liblttng-ctl', '', d), '', d)} \
 "
 MULTILIB_RUNTIME_FEATURE_PACKAGES = "${@' '.join(multilib_pkg_extend(d, pkg) for pkg in d.getVar('MULTILIB_RUNTIME_PACKAGES').split())}"
 FEATURE_PACKAGES_multilib-runtime ?= "${@d.getVar('MULTILIB_RUNTIME_FEATURE_PACKAGES') if not d.getVar('MLPREFIX') else ''}"

--- a/meta-sokol-flex-staging/recipes-kernel/lttng/lttng-tools/0001-Ensure-that-the-consumerd-configure-arguments-are-us.patch
+++ b/meta-sokol-flex-staging/recipes-kernel/lttng/lttng-tools/0001-Ensure-that-the-consumerd-configure-arguments-are-us.patch
@@ -1,0 +1,57 @@
+From 0d09ed08a84ec77e01bede24847f4ced4e99057c Mon Sep 17 00:00:00 2001
+From: Christopher Larson <chris_larson@mentor.com>
+Date: Fri, 29 Sep 2023 17:07:30 -0500
+Subject: [PATCH] Ensure that the consumerd configure arguments are used
+
+Currently, the --with-consumerd32-bin, --with-consumerd32-libdir, etc arguments
+are not being used by lttng-sessiond, which causes problems with providing a
+well configured multilib tracing environment. Ensure that they are used as the
+default values in sessiond.
+
+Signed-off-by: Christopher Larson <chris_larson@mentor.com>
+---
+Upstream-Status: Pending
+
+diff --git a/src/bin/lttng-sessiond/sessiond-config.c b/src/bin/lttng-sessiond/sessiond-config.c
+index 05e0ef1..d98876d 100644
+--- a/src/bin/lttng-sessiond/sessiond-config.c
++++ b/src/bin/lttng-sessiond/sessiond-config.c
+@@ -51,14 +51,14 @@ struct sessiond_config sessiond_config_build_defaults = {
+ 	.load_session_path.value =		NULL,
+ 
+ 	.consumerd32_path.value =		NULL,
+-	.consumerd32_bin_path.value =		NULL,
+-	.consumerd32_lib_dir.value =		NULL,
++	.consumerd32_bin_path.value =		DEFAULT_USTCONSUMERD32_BIN,
++	.consumerd32_lib_dir.value =		DEFAULT_USTCONSUMERD32_LIBDIR,
+ 	.consumerd32_err_unix_sock_path.value = NULL,
+ 	.consumerd32_cmd_unix_sock_path.value = NULL,
+ 
+ 	.consumerd64_path.value =		NULL,
+-	.consumerd64_bin_path.value =		NULL,
+-	.consumerd64_lib_dir.value =		NULL,
++	.consumerd64_bin_path.value =		DEFAULT_USTCONSUMERD64_BIN,
++	.consumerd64_lib_dir.value =		DEFAULT_USTCONSUMERD64_LIBDIR,
+ 	.consumerd64_err_unix_sock_path.value = NULL,
+ 	.consumerd64_cmd_unix_sock_path.value = NULL,
+ 
+diff --git a/src/common/defaults.h b/src/common/defaults.h
+index 3017a38..9880d13 100644
+--- a/src/common/defaults.h
++++ b/src/common/defaults.h
+@@ -70,11 +70,15 @@
+ #define DEFAULT_KCONSUMERD_ERR_SOCK_PATH        DEFAULT_KCONSUMERD_PATH "/error"
+ 
+ /* UST 64-bit consumer path */
++#define DEFAULT_USTCONSUMERD64_BIN              CONFIG_CONSUMERD64_BIN
++#define DEFAULT_USTCONSUMERD64_LIBDIR           CONFIG_CONSUMERD64_LIBDIR
+ #define DEFAULT_USTCONSUMERD64_PATH             DEFAULT_CONSUMERD_RUNDIR "/ustconsumerd64"
+ #define DEFAULT_USTCONSUMERD64_CMD_SOCK_PATH    DEFAULT_USTCONSUMERD64_PATH "/command"
+ #define DEFAULT_USTCONSUMERD64_ERR_SOCK_PATH    DEFAULT_USTCONSUMERD64_PATH "/error"
+ 
+ /* UST 32-bit consumer path */
++#define DEFAULT_USTCONSUMERD32_BIN              CONFIG_CONSUMERD32_BIN
++#define DEFAULT_USTCONSUMERD32_LIBDIR           CONFIG_CONSUMERD32_LIBDIR
+ #define DEFAULT_USTCONSUMERD32_PATH             DEFAULT_CONSUMERD_RUNDIR "/ustconsumerd32"
+ #define DEFAULT_USTCONSUMERD32_CMD_SOCK_PATH    DEFAULT_USTCONSUMERD32_PATH "/command"
+ #define DEFAULT_USTCONSUMERD32_ERR_SOCK_PATH    DEFAULT_USTCONSUMERD32_PATH "/error"

--- a/meta-sokol-flex-staging/recipes-kernel/lttng/lttng-tools_%.bbappend
+++ b/meta-sokol-flex-staging/recipes-kernel/lttng/lttng-tools_%.bbappend
@@ -6,8 +6,11 @@ FILESEXTRAPATHS:prepend:feature-sokol-flex-staging := "${THISDIR}/lttng-tools:"
 
 SRC_URI:append:feature-sokol-flex-staging = " file://0001-Ensure-that-the-consumerd-configure-arguments-are-us.patch"
 
+STAGING_ENABLED = ""
+STAGING_ENABLED:feature-sokol-flex-staging = "1"
+
 python () {
-    if not d.getVar('MULTILIBS'):
+    if not d.getVar('MULTILIBS') or not d.getVar('STAGING_ENABLED'):
         return
 
     variants = (d.getVar("MULTILIB_VARIANTS") or "").split()

--- a/meta-sokol-flex-staging/recipes-kernel/lttng/lttng-tools_%.bbappend
+++ b/meta-sokol-flex-staging/recipes-kernel/lttng/lttng-tools_%.bbappend
@@ -1,3 +1,11 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# SPDX-License-Identifier: MIT
+# ---------------------------------------------------------------------------------------------------------------------
+
+FILESEXTRAPATHS:prepend:feature-sokol-flex-staging := "${THISDIR}/lttng-tools:"
+
+SRC_URI:append:feature-sokol-flex-staging = " file://0001-Ensure-that-the-consumerd-configure-arguments-are-us.patch"
+
 python () {
     if not d.getVar('MULTILIBS'):
         return

--- a/meta-sokol-flex-staging/recipes-kernel/lttng/lttng-tools_%.bbappend
+++ b/meta-sokol-flex-staging/recipes-kernel/lttng/lttng-tools_%.bbappend
@@ -28,3 +28,15 @@ python () {
     d.appendVar('EXTRA_OECONF', ' --with-consumerd32-libdir=' + lib32path)
     d.appendVar('EXTRA_OECONF', ' --with-consumerd32-bin=' + os.path.join(lib32path, 'lttng', 'libexec', 'lttng-consumerd'))
 }
+
+# Split off components which should be per-multilib
+PACKAGE_BEFORE_PN:prepend:feature-sokol-flex-staging = "${PN}-consumerd liblttng-ctl "
+
+RDEPENDS:${PN}:append:feature-sokol-flex-staging = " ${PN}-consumerd ${MLPREFIX}liblttng-ctl"
+
+FILES:${PN}-consumerd = "${libdir}/lttng/libexec/lttng-consumerd"
+# Since files are installed into ${libdir}/lttng/libexec we match
+# the libexec insane test so skip it.
+INSANE_SKIP:${PN}-consumerd = "dev-so"
+
+FILES:${MLPREFIX}liblttng-ctl = "${libdir}/liblttng-ctl.so.*"


### PR DESCRIPTION
* Patch lttng-tools to obey its configure arguments for consumerd paths for multilibs
* Adjust lttng-tools packaging to avoid 32-bit binaries overwriting 64-bit ones