### PR TITLE
openssl: quiet multilib QA warning about suspicious value

### DIFF
--- a/meta-sokol-flex-staging/recipes-connectivity/openssl/openssl_%.bbappend
+++ b/meta-sokol-flex-staging/recipes-connectivity/openssl/openssl_%.bbappend
@@ -1,0 +1,1 @@
+PACKAGEFUNCS:remove = " do_package_qa_multilib"


### PR DESCRIPTION
Ignore the do_package_qa_multilib check to suppress this warning:

WARNING: lib32-openssl-3.0.9-r0 do_package: QA Issue: lib32-openssl package lib32-openssl - suspicious values 'cryptodev-module' in RRECOMMENDS [multilib]

The do_package_qa_multilib PACKAGE FUNC does not obey INSANE_SKIP so we modify it directly. In the long term, we should also consider fixing the upstream class to obey INSANE_SKIP properly.

JIRA: SB-22762