### PR TITLE
conf/multiconfig: add support for multiconfig

### DIFF
--- a/conf/multiconfig/dom0.conf
+++ b/conf/multiconfig/dom0.conf
@@ -1,0 +1,35 @@
+# This material contains trade secrets or otherwise confidential information owned by Siemens Industry Software Inc.
+# or its affiliates (collectively, "Siemens"), or its licensors. Access to and use of this information is strictly limited
+# as set forth in the Customer's applicable agreements with Siemens.
+# ---------------------------------------------------------------------------------------------------------------------
+# Unpublished work. Copyright 2024 Siemens
+# ---------------------------------------------------------------------------------------------------------------------
+
+# Make override for dom0 multiconfig
+OVERRIDES:append = ":dom0"
+
+# Set TMPDIR for dom0 build
+TMPDIR = "${TOPDIR}/tmp-dom0"
+
+# Default is set to 0, means no user domain to be created.
+XEN_TOTAL_USER_DOMAINS = "0"
+
+# For each user domain, declare below set of variables. For example, XEN_DOMU2_KERNEL, XEN_DOMU3_KERNEL etc.
+# We assume that the artifacts for domUs are pre-built. Specify absoulte paths for domU artifacts.
+# Unit of domU memory is considered MB.
+# By-default, the paths are set for xen-guest-image-minimal artifacts from deploy dir.
+#XEN_DOMU1_KERNEL = "${TOPDIR}/tmp-domu/deploy/images/${MACHINE}/Image"
+#XEN_DOMU1_RAMDISK = "${TOPDIR}/tmp-domu/deploy/images/${MACHINE}/xen-guest-image-minimal-qemuarm64.rootfs.cpio.gz"
+#XEN_DOMU1_CPU_COUNT = "1"
+#XEN_DOMU1_MEMORY = "2048"
+#XEN_DOMU1_DISK_IMAGE = "<absolute_path_to_domu1_disk_image>"
+
+# Add port forwarding for SSH and Debug.
+QB_SLIRP_OPT = "-netdev user,id=net0,hostfwd=tcp::2222-:22,hostfwd=tcp::10000-:10000"
+
+# Set ext4 as default FS type for Qemu boot
+QB_DEFAULT_FSTYPE = "ext4"
+QB_MEM_VALUE = "8192"
+QB_SMP = "-smp 8"
+QB_MACHINE:append = " -machine virt,iommu=smmuv3"
+QB_XEN_CMDLINE_EXTRA = "dom0_mem=2048M iommu=1 iommu=debug iommu=verbose"

--- a/conf/multiconfig/domu.conf
+++ b/conf/multiconfig/domu.conf
@@ -1,0 +1,12 @@
+# This material contains trade secrets or otherwise confidential information owned by Siemens Industry Software Inc.
+# or its affiliates (collectively, "Siemens"), or its licensors. Access to and use of this information is strictly limited
+# as set forth in the Customer's applicable agreements with Siemens.
+# ---------------------------------------------------------------------------------------------------------------------
+# Unpublished work. Copyright 2024 Siemens
+# ---------------------------------------------------------------------------------------------------------------------
+
+# Make override for domu multiconfig
+OVERRIDES:append = ":domu"
+
+# Set TMPDIR for domu build
+TMPDIR = "${TOPDIR}/tmp-domu"

--- a/scripts/setup-flex-builddir
+++ b/scripts/setup-flex-builddir
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-2.0
 # ---------------------------------------------------------------------------------------------------------------------
 #
-# Copyright 2022 Siemens
+# Copyright 2024 Siemens
 #
 # This file is licensed under the terms of the GNU General Public License
 # version 2.  This program  is licensed "as is" without any warranty of any
@@ -275,7 +275,7 @@ setup_builddir () {
         existing_builddir=0
     fi
 
-    mkdir -p $BUILDDIR/conf
+    mkdir -p $BUILDDIR/conf/multiconfig
 
     if [ -z "$TEMPLATECONF" ]; then
         if [ -f "$BUILDDIR/conf/templateconf.cfg" ]; then
@@ -299,6 +299,26 @@ setup_builddir () {
     else
         if [ -n "$MACHINE" ]; then
             echo "Configuring existing local.conf for $MACHINE"
+        fi
+    fi
+
+    if [ ! -e $BUILDDIR/conf/multiconfig/dom0.conf ]; then
+        cp $TEMPLATECONF/multiconfig/dom0.conf $BUILDDIR/conf/multiconfig/dom0.conf
+        echo "You had no multiconfig/dom0.conf file. This configuration file has therefore been"
+        echo "created for you with some default values."
+    else
+        if [ -n "$MACHINE" ]; then
+            echo "Configuring existing multiconfig/dom0.conf for $MACHINE"
+        fi
+    fi
+
+    if [ ! -e $BUILDDIR/conf/multiconfig/domu.conf ]; then
+        cp $TEMPLATECONF/multiconfig/domu.conf $BUILDDIR/conf/multiconfig/domu.conf
+        echo "You had no multiconfig/domu.conf file. This configuration file has therefore been"
+        echo "created for you with some default values."
+    else
+        if [ -n "$MACHINE" ]; then
+            echo "Configuring existing multiconfig/domu.conf for $MACHINE"
         fi
     fi
 


### PR DESCRIPTION
This updates setup-flex-builddir script to by default create multiconfigs for dom0 and domU. This also adds sample conf files for both multiconfigs.

JIRA: https://jira.alm.mentorg.com/browse/AT1-8