### PR TITLE
setup-checkout: fix bug in showing only the latest version of manifest

### DIFF
--- a/scripts/release/flex-checkout
+++ b/scripts/release/flex-checkout
@@ -110,17 +110,15 @@ prompt_choice () {
 }
 
 remove_old_versions () {
-    while IFS=- read -r product version machine; do
-        printf '%s\t%s\t%s\n' "$product" "$version" "$machine"
-    done \
+    sed -e 's/\-\([0-9]\+\.[0-9]\+\.[0-9]\+\)\-/'$'\t\\1\t/g' \
     | uniq -f2 \
     | tr "$(printf '\t')" -
 }
 
 sort_manifests () {
-    sort -V \
-    | tac \
-    | sort -s -t- -k3 \
+    sed -e 's/\-\([0-9]\+\.[0-9]\+\.[0-9]\+\)\-/'$'\t\\1\t/g' \
+    | sort -rV -k2 \
+    | tr "$(printf '\t')" - \
     | if [ $all_versions -eq 0 ]; then remove_old_versions; else cat; fi \
     | sed '/qemu/!s/^/1 /; /qemu/s/^/0 /;' | sort -srn | sed 's/^[01] //'
 }


### PR DESCRIPTION
The implementation was originally written assuming that the release version will be of the type `<product>-<version>-<machine>` where the product name will not have any dash (-) character. Since we are using either sokol-flex or flex-os, the implementation needs to be updated.

Updated the implementation to first use sed to replace the string `-<version>-` into `\t<version>\t`. Then sorted on basis of version and then brought back dashes (-).

NOTE: The updated implementation assumes that the version will conform to semantic versioning format i.e. `[0-9]+.[0-9]+.[0-9]+`. If this changes in future, the implementation needs to be updated accordingly.

JIRA-ID: SB-23356