### PR TITLE
setup-checkout: fix bug in showing latest manifest version of each BSPs

### DIFF
--- a/scripts/release/flex-checkout
+++ b/scripts/release/flex-checkout
@@ -118,6 +118,7 @@ remove_old_versions () {
 sort_manifests () {
     sed -e 's/\-\([0-9]\+\.[0-9]\+\.[0-9]\+\)\-/'$'\t\\1\t/g' \
     | sort -rV -k2 \
+    | sort -s -k3 \
     | tr "$(printf '\t')" - \
     | if [ $all_versions -eq 0 ]; then remove_old_versions; else cat; fi \
     | sed '/qemu/!s/^/1 /; /qemu/s/^/0 /;' | sort -srn | sed 's/^[01] //'


### PR DESCRIPTION
This is in continuation of commit
84d62b4a073300fb225665d9af04675dcfcd7e8e

This handles the case where there could be multiple versions of multiple BSPs installed. This will show the latest version of each BSP.