### PR TITLE
virtualization-layer: provide option to add extra-space

### DIFF
--- a/meta-sokol-flex-distro/dynamic-layers/virtualization-layer/conf/local.conf.append
+++ b/meta-sokol-flex-distro/dynamic-layers/virtualization-layer/conf/local.conf.append
@@ -1,2 +1,5 @@
 # Comment out the following to disable virtualization support
 USER_FEATURES += "virtualization"
+
+# Uncomment to add extra-space to rootfs (default: 204800KB) for virtualization only
+#IMAGE_ROOTFS_EXTRA_SPACE:append = "${@bb.utils.contains('USER_FEATURES', 'virtualization', ' + 204800', '', d)}"


### PR DESCRIPTION
The user may need extra space when virtualization feature is enabled. Even for our QVTs where we pull ubuntu docker and try installing some packages in it, we need around 200M of additional space.

JIRA-ID: SB-23366