### PR TITLE
librsvg-2.52.10: use OSS compliant source

### DIFF
--- a/meta-sokol-flex-distro/dynamic-layers/openembedded-layer/recipes-gnome/librsvg/librsvg_2.52.10.bbappend
+++ b/meta-sokol-flex-distro/dynamic-layers/openembedded-layer/recipes-gnome/librsvg/librsvg_2.52.10.bbappend
@@ -1,0 +1,8 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# SPDX-License-Identifier: MIT
+# ---------------------------------------------------------------------------------------------------------------------
+
+SRC_URI:remove = "${GNOME_MIRROR}/${GNOMEBN}/${@gnome_verdir("${PV}")}/${GNOMEBN}-${PV}.tar.${GNOME_COMPRESS_TYPE};name=archive"
+SRC_URI:prepend = "https://github.com/MentorEmbedded/flex_package_source/releases/download/${BPN}-${PV}/${BPN}-${PV}.tar.gz;name=archive "
+
+SRC_URI[archive.sha256sum] = "66e6a26b1abb103cbbfe1c7b6f97e9c48f4a33e8df17ca0a84f7af2bc896ef1d"


### PR DESCRIPTION
We maintain modified sources in repo:
https://github.com/MentorEmbedded/flex_package_source/

These sources are OSS compliant and remove objectionable binaries as compared to the original sources.

JIRA-ID: SB-23487