### PR TITLE
sokol-flex.conf: Add ML layer distro conf snippet

### DIFF
--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -365,6 +365,9 @@ include conf/distro/include/flex-iot.conf
 # MCF configuration
 include conf/distro/include/flex-mcf.conf
 
+# ML configuration
+include conf/distro/include/flex-ml.conf
+
 # INITRAMFS
 INITRAMFS_IMAGE ?= "flex-initramfs-image"
 INITRAMFS_IMAGE_BUNDLE ?= "${@bb.utils.contains('KERNEL_IMAGETYPES', 'fitImage', '', '1', d)}"


### PR DESCRIPTION
This adds a distro conf include file for the optional flex-ml layer

JIRA-ID: SB-22739