### PR TITLE
Add rebranding changes and few more fixes for encountered issues due to Yocto5 update

### DIFF
--- a/meta-sokol-flex-common/classes/codebench-environment-setup-d-hack.bbclass
+++ b/meta-sokol-flex-common/classes/codebench-environment-setup-d-hack.bbclass
@@ -3,7 +3,7 @@
 # ---------------------------------------------------------------------------------------------------------------------
 
 # Work around lack of support for environment-setup.d in CodeBench
-SDK_PACKAGING_COMMAND:prepend:sdk-codebench-metadata = "merge_environment_setup_d; add_no_sysroot_suffix;"
+SDK_PACKAGING_COMMAND:prepend:sdk-codebench-metadata = "merge_environment_setup_d add_no_sysroot_suffix "
 
 merge_environment_setup_d() {
     for setup_d in "${SDK_OUTPUT}${SDKPATH}/sysroots/"*/environment-setup.d; do

--- a/meta-sokol-flex-common/classes/deploy-license-manifest.bbclass
+++ b/meta-sokol-flex-common/classes/deploy-license-manifest.bbclass
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: MIT
 # ---------------------------------------------------------------------------------------------------------------------
 
-ROOTFS_POSTPROCESS_COMMAND += "deploy_license_manifest;"
-IMAGE_POSTPROCESS_COMMAND += "link_license_manifest;"
+ROOTFS_POSTPROCESS_COMMAND += "deploy_license_manifest"
+IMAGE_POSTPROCESS_COMMAND += "link_license_manifest"
 
 deploy_license_manifest () {
     if [ -e "${LICENSE_DIRECTORY}/${IMAGE_NAME}/license.manifest" ]; then

--- a/meta-sokol-flex-common/classes/rootfs-disable-tty1-login.bbclass
+++ b/meta-sokol-flex-common/classes/rootfs-disable-tty1-login.bbclass
@@ -1,6 +1,6 @@
 # Disable the login on tty1 if the 'disable-tty1-login' image feature is set
 
-ROOTFS_POSTPROCESS_COMMAND += '${@bb.utils.contains("IMAGE_FEATURES", "disable-tty1-login", "disable_tty1_login; ", "",d)}'
+ROOTFS_POSTPROCESS_COMMAND += '${@bb.utils.contains("IMAGE_FEATURES", "disable-tty1-login", "disable_tty1_login", "",d)}'
 
 FEATURE_PACKAGES_disable-tty1-login = ""
 

--- a/meta-sokol-flex-common/classes/sdk_codebench_metadata.bbclass
+++ b/meta-sokol-flex-common/classes/sdk_codebench_metadata.bbclass
@@ -9,7 +9,7 @@ inherit sdk_multilib_hook sdk_extra_vars codebench-environment-setup-d-hack
 
 OVERRIDES =. "${@bb.utils.contains('SDKIMAGE_FEATURES', 'codebench-metadata', 'sdk-codebench-metadata:', '', d)}"
 
-SDK_POSTPROCESS_MULTILIB_COMMAND:prepend:sdk-codebench-metadata = "adjust_sdk_script_codebench; write_cb_mbs_options;"
+SDK_POSTPROCESS_MULTILIB_COMMAND:prepend:sdk-codebench-metadata = "adjust_sdk_script_codebench write_cb_mbs_options "
 
 TOOLCHAIN_HOST_TASK:append:sdk-codebench-metadata = " ${@bb.utils.contains('BBFILE_COLLECTIONS', 'sokol-flex-support', 'nativesdk-relocate-makefile', '', d)}"
 TOOLCHAIN_TARGET_TASK:append:sdk-codebench-metadata = " ${@bb.utils.contains('BBFILE_COLLECTIONS', 'sokol-flex-support', 'codebench-makefile', '', d)}"

--- a/meta-sokol-flex-common/classes/sdk_codebench_metadata.bbclass
+++ b/meta-sokol-flex-common/classes/sdk_codebench_metadata.bbclass
@@ -117,7 +117,6 @@ def get_cb_options(d):
     options = d.getVarFlags('CB_MBS_OPTIONS') or {}
 
     l = d.createCopy()
-    l.finalize()
     l.setVar('DEBUG_PREFIX_MAP', '')
     l.setVar('STAGING_DIR_TARGET', '$SDKTARGETSYSROOT')
 

--- a/meta-sokol-flex-common/classes/sdk_extra_vars.bbclass
+++ b/meta-sokol-flex-common/classes/sdk_extra_vars.bbclass
@@ -10,7 +10,7 @@ EXTRA_SDK_VARS ?= ""
 EXTRA_EXPORTED_SDK_VARS ?= ""
 EXTRA_SDK_LINES ?= ""
 
-SDK_POSTPROCESS_MULTILIB_COMMAND += "add_sdk_extra_vars;"
+SDK_POSTPROCESS_MULTILIB_COMMAND += "add_sdk_extra_vars"
 
 add_sdk_extra_vars () {
     if [ -e "${SDK_ENV_SETUP_SCRIPT}" ]; then

--- a/meta-sokol-flex-common/classes/sdk_latest_link.bbclass
+++ b/meta-sokol-flex-common/classes/sdk_latest_link.bbclass
@@ -4,7 +4,7 @@
 
 TOOLCHAIN_LINKNAME ?= "${@'${TOOLCHAIN_OUTPUTNAME}'.replace('-${SDK_VERSION}', '')}"
 
-SDK_POSTPROCESS_COMMAND:append = "create_sdk_link;"
+SDK_POSTPROCESS_COMMAND:append = " create_sdk_link"
 
 create_sdk_link () {
     if [ "${TOOLCHAIN_OUTPUTNAME}" != "${TOOLCHAIN_LINKNAME}" ]; then

--- a/meta-sokol-flex-common/classes/sdk_multilib_hook.bbclass
+++ b/meta-sokol-flex-common/classes/sdk_multilib_hook.bbclass
@@ -9,7 +9,7 @@ SDK_POSTPROCESS_MULTILIB_COMMAND ?= ""
 REAL_MULTIMACH_TARGET_SYS ?= "${TUNE_PKGARCH}${TARGET_VENDOR}-${TARGET_OS}"
 SDK_ENV_SETUP_SCRIPT ?= "${SDK_OUTPUT}/${SDKPATH}/environment-setup-${REAL_MULTIMACH_TARGET_SYS}"
 
-SDK_POSTPROCESS_COMMAND:prepend = "sdk_postprocess_per_multilib;"
+SDK_POSTPROCESS_COMMAND:prepend = "sdk_postprocess_per_multilib "
 
 python sdk_postprocess_per_multilib () {
     # Handle multilibs in the SDK environment, siteconfig, etc files...
@@ -22,7 +22,7 @@ python sdk_postprocess_per_multilib () {
     localdata.setVar('SDKTARGETSYSROOT', d.getVar('SDKTARGETSYSROOT'))
     localdata.setVar('libdir', d.getVar('target_libdir', False))
 
-    commands = [cmd.strip() for cmd in d.getVar('SDK_POSTPROCESS_MULTILIB_COMMAND').split(';')]
+    commands = [cmd.strip() for cmd in d.getVar('SDK_POSTPROCESS_MULTILIB_COMMAND').split()]
     variants = d.getVar("MULTILIB_VARIANTS") or ""
     for variant in [''] + variants.split():
         if variant:

--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -6,7 +6,8 @@
 DISTRO_NAME = "Flex OS"
 DISTRO_CODENAME = "scarthgap"
 MAINTAINER = "Siemens Digital Industries Software <embedded_support@mentor.com>"
-HOME_URL = "https://www.plm.automation.siemens.com/global/en/products/embedded/flex-os.html"
+# TODO: Fix the URL below, the following URL is not valid
+#HOME_URL = "https://www.plm.automation.siemens.com/global/en/products/embedded/flex-os.html"
 SUPPORT_URL = "https://support.sw.siemens.com/"
 BUG_REPORT_URL = "https://support.sw.siemens.com/"
 
@@ -271,11 +272,15 @@ SDK_DEPLOY:sokol-flex = "${DEPLOY_DIR_SDK}"
 DEPLOY_DIR_SDK ?= "${DEPLOY_DIR}/sdk"
 
 # Use distro rather than oecore
-SDK_NAME_PREFIX = "${DISTRO}"
+# TODO: Hardcoding flex-os instead of ${DISTRO}, revert once DISTRO variable is up-to-date as
+# per new brand name
+SDK_NAME_PREFIX = "flex-os"
 
 # Adjust installer name and default install path
 SDK_NAME = "${SDK_NAME_PREFIX}-${SDK_VERSION}-${IMAGE_BASENAME}-${MACHINE}"
-SDKPATHINSTALL = "~/${DISTRO}/sdk/${SDK_VERSION}/${IMAGE_BASENAME}-${MACHINE}"
+# TODO: Hardcoding flex-os instead of ${DISTRO}, revert once DISTRO variable is up-to-date as
+# per new brand name
+SDKPATHINSTALL = "~/flex-os/sdk/${SDK_VERSION}/${IMAGE_BASENAME}-${MACHINE}"
 
 # Current multilib prefix, for non-multilib images. Ex. the lib32
 # environment-setup within a non-lib32 image SDK.

--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -97,6 +97,10 @@ require conf/distro/include/no-static-libs.inc
 require conf/distro/include/yocto-uninative.inc
 
 INHERIT += "uninative"
+
+# Remove SPDX creation by default
+INHERIT_DISTRO:remove = "create-spdx"
+
 ## }}}1
 ## Mechanisms provided for user customization {{{1
 # Support USER_FEATURES

--- a/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
+++ b/meta-sokol-flex-distro/conf/distro/sokol-flex.conf
@@ -83,7 +83,7 @@ UBI_VOLNAME = "rootfs"
 IMAGE_LINGUAS ?= "en-us"
 
 # Also check for host user contamination in the rootfs
-ROOTFS_POSTPROCESS_COMMAND:append = " rootfs_check_host_user_contaminated;"
+ROOTFS_POSTPROCESS_COMMAND:append = " rootfs_check_host_user_contaminated"
 
 # Default to systemd, not sysvinit
 INIT_MANAGER ?= "systemd"

--- a/meta-sokol-flex-distro/conf/templates/default/conf-notes.txt
+++ b/meta-sokol-flex-distro/conf/templates/default/conf-notes.txt
@@ -1,8 +1,5 @@
 
-Common bitbake targets are:
+Common bitbake target is:
 
     development-image
-    production-image
 
-production-image requires that the ROOT_PASSWORD variable be set. See
-conf/local.conf for details.

--- a/meta-sokol-flex-distro/conf/templates/default/local.conf.sample
+++ b/meta-sokol-flex-distro/conf/templates/default/local.conf.sample
@@ -27,7 +27,7 @@ EXTRA_IMAGE_FEATURES ?= "multilib-runtime"
 # Image features for development-image
 IMAGE_FEATURES_DEVELOPMENT ?= "debug-tweaks"
 IMAGE_FEATURES_DEVELOPMENT:append:flex-bsp = " codebench-debug ssh-server-openssh"
-EXTRA_IMAGE_FEATURES = "${IMAGE_FEATURES_DEVELOPMENT} multilib-runtime splash"
+EXTRA_IMAGE_FEATURES = "${IMAGE_FEATURES_DEVELOPMENT} multilib-runtime"
 
 # Image features for production-image
 IMAGE_FEATURES_PRODUCTION ?= ""

--- a/meta-sokol-flex-staging/classes/populate_sdk_qt6_base.bbclass
+++ b/meta-sokol-flex-staging/classes/populate_sdk_qt6_base.bbclass
@@ -1,6 +1,6 @@
 inherit qt6-paths
 
-SDK_POSTPROCESS_COMMAND:prepend = "create_qt6_sdk_files;"
+SDK_POSTPROCESS_COMMAND:prepend = "create_qt6_sdk_files "
 
 EXE_EXT = ""
 EXE_EXT:sdkmingw32 = ".exe"

--- a/meta-sokol-flex-support/recipes-core/images/flex-initramfs-image.bb
+++ b/meta-sokol-flex-support/recipes-core/images/flex-initramfs-image.bb
@@ -27,7 +27,7 @@ IMAGE_QA_COMMANDS:remove = "image_check_zapped_root_password"
 BAD_RECOMMENDATIONS += "busybox-syslog"
 
 # We don't need selinux labels in initramfs
-IMAGE_PREPROCESS_COMMAND:remove = "selinux_set_labels ;"
+IMAGE_PREPROCESS_COMMAND:remove = "selinux_set_labels"
 
 # Take care of warnings due to dependency on noexec ${INITRAMFS_IMAGE}:do_image_complete's
 # do_packagedata() in our initramfs image for now. The fix needs to come from oe-core image

--- a/meta-sokol-flex-support/recipes-core/meta/archive-release.bb
+++ b/meta-sokol-flex-support/recipes-core/meta/archive-release.bb
@@ -19,11 +19,13 @@ BINARY_ARTIFACTS_COMPRESSION ?= ""
 BINARY_ARTIFACTS_COMPRESSION[doc] = "Compression type for images and downloads artifacts.\
  Available: '.bz2' and '.gz'. No compression if empty"
 
+# TODO: Hardcoding flex-os instead of ${DISTRO}, revert once DISTRO variable is up-to-date as
+# per new brand name
 ARCHIVE_RELEASE_VERSION ?= "${DISTRO_VERSION}"
-MANIFEST_NAME ?= "${DISTRO}-${ARCHIVE_RELEASE_VERSION}-${MACHINE}"
-EXTRA_MANIFEST_NAME ?= "${DISTRO}-${ARCHIVE_RELEASE_VERSION}"
+MANIFEST_NAME ?= "flex-os-${ARCHIVE_RELEASE_VERSION}-${MACHINE}"
+EXTRA_MANIFEST_NAME ?= "flex-os-${ARCHIVE_RELEASE_VERSION}"
 SCRIPTS_VERSION ?= "0"
-SCRIPTS_ARTIFACT_NAME ?= "${DISTRO}-scripts-${DISTRO_VERSION}.${SCRIPTS_VERSION}"
+SCRIPTS_ARTIFACT_NAME ?= "flex-os-scripts-${DISTRO_VERSION}.${SCRIPTS_VERSION}"
 
 # Don't allow git to chdir up past our workspace to avoid redistributing the wrong repository
 export GIT_CEILING_DIRECTORIES = "${WORKDIR}:${FLEXDIR}:${TOPDIR}:${HOME}"

--- a/scripts/release/setup-flex
+++ b/scripts/release/setup-flex
@@ -43,7 +43,7 @@ else
     unset flex_arg
     "$flexdir/scripts/setup-workspace" "$@" && \
     cd "$WORKSPACEDIR" && \
-    echo >&2 "Sokol Flex OS setup complete in $WORKSPACEDIR" && \
+    echo >&2 "Flex OS setup complete in $WORKSPACEDIR" && \
     echo >&2 "You can now source $WORKSPACEDIR/meta-sokol-flex/setup-environment for setting up a build."
 fi
 # vim: set ft=sh :


### PR DESCRIPTION
* setup-flex: remove Sokol keyword from print message
* conf-notes.txt: print only officially supported image
* distro: update variables with new distro name
* The DataSmart.finalize() method has been removed upstream: https://github.com/openembedded/bitbake/commit/584989ed2b5af4e8799571dece0cf94f995ef14e. This was an empty method and now it is completely removed.
* drop ';' delimiter from ROOTFS/IMAGE*COMMAND variables. The variables handling changed upstream: https://github.com/openembedded/openembedded-core/commit/c3365dfd9ddd7fbe70b62e0f11166e57a8ca6f73
* sokol-flex.conf: do not create SPDX by-default