### PR TITLE
qemu-system-native: fix mouse co-ordinates scaling issue

### DIFF
--- a/meta-flex-staging/recipes-devtools/qemu/files/0001-ui-sdl2-fix-mouse-co-ordinates-for-scaled-guest-surf.patch
+++ b/meta-flex-staging/recipes-devtools/qemu/files/0001-ui-sdl2-fix-mouse-co-ordinates-for-scaled-guest-surf.patch
@@ -1,0 +1,74 @@
+From 98a21c4c121ff45b3033619f909bf9c27302628e Mon Sep 17 00:00:00 2001
+From: Haseeb Ashraf <haseeb_ashraf@mentor.com>
+Date: Thu, 13 Jun 2024 12:28:33 +0500
+Subject: ui/sdl2: fix mouse co-ordinates for scaled guest surface
+
+This is noted that when the guest surface is scaled into a smaller
+window on the host, the mouse co-ordinates are not adjusted correctly.
+
+This is part of the patch which is merged in S2S-QEMU:
+http://orw-medusa-vm.wv.mentorg.com/shyam/s2s-qemu/-/commit/1bbdf069bc1e3a1a53b7e4a22375f5dae90150e6
+
+Upstream-Status: Pending
+
+Signed-off-by: Haseeb Ashraf <haseeb_ashraf@mentor.com>
+---
+ ui/sdl2.c | 26 +++++++++++++++++++++-----
+ 1 file changed, 21 insertions(+), 5 deletions(-)
+
+diff --git a/ui/sdl2.c b/ui/sdl2.c
+index 4971963f0..07f18dd79 100644
+--- a/ui/sdl2.c
++++ b/ui/sdl2.c
+@@ -505,9 +505,9 @@ static void handle_mousemotion(SDL_Event *ev)
+         return;
+     }
+ 
++    int scr_w, scr_h;
++    SDL_GetWindowSize(scon->real_window, &scr_w, &scr_h);
+     if (qemu_input_is_absolute(scon->dcl.con) || absolute_enabled) {
+-        int scr_w, scr_h;
+-        SDL_GetWindowSize(scon->real_window, &scr_w, &scr_h);
+         max_x = scr_w - 1;
+         max_y = scr_h - 1;
+         if (gui_grab && !gui_fullscreen
+@@ -521,9 +521,17 @@ static void handle_mousemotion(SDL_Event *ev)
+             sdl_grab_start(scon);
+         }
+     }
++
++    /* adjust mouse co-ordinates when the guest surface is scaled */
++    float x_scale = (float)surface_width(scon->surface) / scr_w;
++    float y_scale = (float)surface_height(scon->surface) / scr_h;
++    int xrel = ev->motion.xrel * x_scale;
++    int yrel = ev->motion.yrel * y_scale;
++    int x = ev->motion.x * x_scale;
++    int y = ev->motion.y * y_scale;
++
+     if (gui_grab || qemu_input_is_absolute(scon->dcl.con) || absolute_enabled) {
+-        sdl_send_mouse_event(scon, ev->motion.xrel, ev->motion.yrel,
+-                             ev->motion.x, ev->motion.y, ev->motion.state);
++        sdl_send_mouse_event(scon, xrel, yrel, x, y, ev->motion.state);
+     }
+ }
+ 
+@@ -549,7 +557,15 @@ static void handle_mousebutton(SDL_Event *ev)
+         } else {
+             buttonstate &= ~SDL_BUTTON(bev->button);
+         }
+-        sdl_send_mouse_event(scon, 0, 0, bev->x, bev->y, buttonstate);
++
++        /* adjust mouse co-ordinates when the guest surface is scaled */
++        int scr_w, scr_h;
++        SDL_GetWindowSize(scon->real_window, &scr_w, &scr_h);
++        float x_scale = (float)surface_width(scon->surface) / scr_w;
++        float y_scale = (float)surface_height(scon->surface) / scr_h;
++        int x = bev->x * x_scale;
++        int y = bev->y * y_scale;
++        sdl_send_mouse_event(scon, 0, 0, x, y, buttonstate);
+     }
+ }
+ 
+-- 
+2.34.1
+

--- a/meta-flex-staging/recipes-devtools/qemu/qemu-system-native_%.bbappend
+++ b/meta-flex-staging/recipes-devtools/qemu/qemu-system-native_%.bbappend
@@ -1,0 +1,7 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# SPDX-License-Identifier: MIT
+# ---------------------------------------------------------------------------------------------------------------------
+
+FILESEXTRAPATHS:prepend:feature-flex-staging := "${THISDIR}/files:"
+
+SRC_URI:append:feature-flex-staging = " file://0001-ui-sdl2-fix-mouse-co-ordinates-for-scaled-guest-surf.patch"


### PR DESCRIPTION
The mouse co-ordinates get out of sync after some time or do not scale properly with screen resolution. This patch fixes this issue.

JIRA-ID: SB-23711