### PR TITLE
DRAFT: qemu-system-native: fix mouse co-ordinates scaling issue

### DIFF
--- a/meta-flex-staging/recipes-devtools/qemu/files/0001-ui-sdl2-fix-mouse-co-ordinates-for-scaled-guest-surf.patch
+++ b/meta-flex-staging/recipes-devtools/qemu/files/0001-ui-sdl2-fix-mouse-co-ordinates-for-scaled-guest-surf.patch
@@ -3,8 +3,10 @@ From: Haseeb Ashraf <haseeb_ashraf@mentor.com>
 Date: Thu, 13 Jun 2024 12:28:33 +0500
 Subject: ui/sdl2: fix mouse co-ordinates for scaled guest surface
 
-This is noted that when the guest surface is scaled into a smaller
-window on the host, the mouse co-ordinates are not adjusted correctly.
+This is noted that when the guest surface is scaled into a window
+other than the default, the mouse co-ordinates are not adjusted
+correctly. Properly select the surface dimensions when SDL,GL is
+enabled.
 
 This is part of the patch which is merged in S2S-QEMU:
 http://orw-medusa-vm.wv.mentorg.com/shyam/s2s-qemu/-/commit/1bbdf069bc1e3a1a53b7e4a22375f5dae90150e6
@@ -13,62 +15,33 @@ Upstream-Status: Pending
 
 Signed-off-by: Haseeb Ashraf <haseeb_ashraf@mentor.com>
 ---
- ui/sdl2.c | 26 +++++++++++++++++++++-----
- 1 file changed, 21 insertions(+), 5 deletions(-)
+ ui/sdl2.c | 13 +++++++++----
+ 1 file changed, 9 insertions(+), 4 deletions(-)
 
 diff --git a/ui/sdl2.c b/ui/sdl2.c
 index 4971963f0..07f18dd79 100644
 --- a/ui/sdl2.c
 +++ b/ui/sdl2.c
-@@ -505,9 +505,9 @@ static void handle_mousemotion(SDL_Event *ev)
-         return;
+@@ -320,10 +320,15 @@
      }
  
-+    int scr_w, scr_h;
-+    SDL_GetWindowSize(scon->real_window, &scr_w, &scr_h);
-     if (qemu_input_is_absolute(scon->dcl.con) || absolute_enabled) {
--        int scr_w, scr_h;
--        SDL_GetWindowSize(scon->real_window, &scr_w, &scr_h);
-         max_x = scr_w - 1;
-         max_y = scr_h - 1;
-         if (gui_grab && !gui_fullscreen
-@@ -521,9 +521,17 @@ static void handle_mousemotion(SDL_Event *ev)
-             sdl_grab_start(scon);
-         }
-     }
-+
-+    /* adjust mouse co-ordinates when the guest surface is scaled */
-+    float x_scale = (float)surface_width(scon->surface) / scr_w;
-+    float y_scale = (float)surface_height(scon->surface) / scr_h;
-+    int xrel = ev->motion.xrel * x_scale;
-+    int yrel = ev->motion.yrel * y_scale;
-+    int x = ev->motion.x * x_scale;
-+    int y = ev->motion.y * y_scale;
-+
-     if (gui_grab || qemu_input_is_absolute(scon->dcl.con) || absolute_enabled) {
--        sdl_send_mouse_event(scon, ev->motion.xrel, ev->motion.yrel,
--                             ev->motion.x, ev->motion.y, ev->motion.state);
-+        sdl_send_mouse_event(scon, xrel, yrel, x, y, ev->motion.state);
-     }
- }
- 
-@@ -549,7 +557,15 @@ static void handle_mousebutton(SDL_Event *ev)
-         } else {
-             buttonstate &= ~SDL_BUTTON(bev->button);
-         }
--        sdl_send_mouse_event(scon, 0, 0, bev->x, bev->y, buttonstate);
-+
-+        /* adjust mouse co-ordinates when the guest surface is scaled */
+     if (qemu_input_is_absolute(scon->dcl.con)) {
+-        qemu_input_queue_abs(scon->dcl.con, INPUT_AXIS_X,
+-                             x, 0, surface_width(scon->surface));
+-        qemu_input_queue_abs(scon->dcl.con, INPUT_AXIS_Y,
+-                             y, 0, surface_height(scon->surface));
 +        int scr_w, scr_h;
-+        SDL_GetWindowSize(scon->real_window, &scr_w, &scr_h);
-+        float x_scale = (float)surface_width(scon->surface) / scr_w;
-+        float y_scale = (float)surface_height(scon->surface) / scr_h;
-+        int x = bev->x * x_scale;
-+        int y = bev->y * y_scale;
-+        sdl_send_mouse_event(scon, 0, 0, x, y, buttonstate);
-     }
- }
- 
++        if (scon->opengl) {
++            SDL_GetWindowSize(scon->real_window, &scr_w, &scr_h);
++        } else {
++            scr_w = surface_width(scon->surface);
++            scr_h = surface_height(scon->surface);
++        }
++        qemu_input_queue_abs(scon->dcl.con, INPUT_AXIS_X, x, 0, scr_w);
++        qemu_input_queue_abs(scon->dcl.con, INPUT_AXIS_Y, y, 0, scr_h);
+     } else {
+         if (guest_cursor) {
+             x -= guest_x;
 -- 
 2.34.1
 


### PR DESCRIPTION
This is in continuation of commit 59cc33db.

The previous commit solved the issue with SDL,GL but since scaling issue was only related to opengl, the scaling shouldn't have been applied otherwise. So, conditionally scale the mouse co-ordinates only for SDL,GL.

Moreover, moved the logic to common place and now the scaling isn't actually required, if we just choose the correct surface dimension based on opengl context.

JIRA-ID: SB-23711