### PR TITLE
common/classes: ensure add_sdk_extra_vars is actually executed

### DIFF
--- a/meta-flex-common/classes/sdk_codebench_metadata.bbclass
+++ b/meta-flex-common/classes/sdk_codebench_metadata.bbclass
@@ -9,7 +9,7 @@ inherit sdk_extra_vars codebench-environment-setup-d-hack
 
 OVERRIDES =. "${@bb.utils.contains('SDKIMAGE_FEATURES', 'codebench-metadata', 'sdk-codebench-metadata:', '', d)}"
 
-SDK_POSTPROCESS_COMMAND:prepend:sdk-codebench-metadata = "adjust_sdk_script_codebench write_cb_mbs_options "
+SDK_POSTPROCESS_COMMAND:prepend:sdk-codebench-metadata = "adjust_sdk_script_codebench write_cb_mbs_options add_sdk_extra_vars "
 
 TOOLCHAIN_HOST_TASK:append:sdk-codebench-metadata = " ${@bb.utils.contains('BBFILE_COLLECTIONS', 'flex-support', 'nativesdk-relocate-makefile', '', d)}"
 TOOLCHAIN_TARGET_TASK:append:sdk-codebench-metadata = " ${@bb.utils.contains('BBFILE_COLLECTIONS', 'flex-support', 'codebench-makefile', '', d)}"
@@ -37,6 +37,8 @@ CB_MBS_OPTIONS ?= ""
 CB_MBS_OPTIONS_FEATURES_MAP ?= ""
 CB_MBS_OPTIONS_FLAGS_MAP ?= ""
 CB_MBS_OPTIONS_FLAGS_VALUE_MAP ?= ""
+
+CB_MBS_OPTIONS[general.yocto.sdk.value] = "${REAL_MULTIMACH_TARGET_SYS}"
 
 CB_MBS_OPTIONS_CC_FLAGS_MAP ?= ""
 CB_MBS_OPTIONS_CC_FLAGS_MAP[-g] = "compiler*option.debugging.level=debugging.level.default"

--- a/meta-flex-common/classes/sdk_extra_vars.bbclass
+++ b/meta-flex-common/classes/sdk_extra_vars.bbclass
@@ -12,8 +12,6 @@ EXTRA_SDK_LINES ?= ""
 REAL_MULTIMACH_TARGET_SYS ?= "${TUNE_PKGARCH}${TARGET_VENDOR}-${TARGET_OS}"
 SDK_ENV_SETUP_SCRIPT ?= "${SDK_OUTPUT}/${SDKPATH}/environment-setup-${REAL_MULTIMACH_TARGET_SYS}"
 
-SDK_POSTPROCESS_COMMAND += "add_sdk_extra_vars"
-
 add_sdk_extra_vars () {
     if [ -e "${SDK_ENV_SETUP_SCRIPT}" ]; then
         cat <<END >>"${SDK_ENV_SETUP_SCRIPT}"


### PR DESCRIPTION
This is in continuation of c2086302 where this issue originates.

Either the sdk_extra_vars.bbclass should be directly included in distro conf file or the function add_sdk_extra_vars should be added to SDK_POSTPROCESS_COMMAND in the bbclass that is directly included in distro conf such as sdk_codebench_metadata. This fix will ensure that environment variables are added to the SDK so that SDK is visible in CodeBench.

Also bring back the option: `CB_MBS_OPTIONS[general.yocto.sdk.value]`

JIRA-ID: SB-23686