### PR TITLE
development-image: do not overwrite IMAGE_FEATURES default value

### DIFF
--- a/meta-flex-support/recipes-core/images/development-image.bb
+++ b/meta-flex-support/recipes-core/images/development-image.bb
@@ -5,7 +5,7 @@
 SUMMARY = "A development/debugging image that fully supports the target \
 device hardware."
 
-IMAGE_FEATURES = " \
+IMAGE_FEATURES:append = " \
     codebench-debug \
     debug-tweaks \
     package-management \


### PR DESCRIPTION
Overwriting the image features default value excludes the EXTRA_IMAGE_FEATURES. So, use append here to add features to the IMAGE_FEATURES.

JIRA-ID: SB-23686