### PR TITLE
staging: yocto-cfg-fragments: include missing configs for docker

### DIFF
--- a/meta-flex-staging/dynamic-layers/virtualization-layer/recipes-kernel/linux/files/0001-cfg-docker.cfg-enable-CONFIG_BPF_SYSCALL.patch
+++ b/meta-flex-staging/dynamic-layers/virtualization-layer/recipes-kernel/linux/files/0001-cfg-docker.cfg-enable-CONFIG_BPF_SYSCALL.patch
@@ -1,0 +1,42 @@
+From fcb30c6faad9e44c96df5546342e63ce06810a6c Mon Sep 17 00:00:00 2001
+From: Haseeb Ashraf <haseeb_ashraf@mentor.com>
+Date: Wed, 4 Dec 2024 10:24:11 +0500
+Subject: [PATCH 1/2] cfg/docker.cfg: enable CONFIG_BPF_SYSCALL
+
+CONFIG_CGROUPS_BPF depends on CONFIG_BPF_SYSCALL. If the latter is
+not enabled in defconfig, then CONFIG_CGROUPS_BPF is not actually
+enabled and results in error:
+```
+docker: Error response from daemon:
+        failed to create task for container:
+        failed to create shim task:
+        OCI runtime create failed:
+        runc create failed:
+        unable to start container process:
+        error during container init:
+        error setting cgroup config for procHooks process:
+        bpf_prog_query(BPF_CGROUP_DEVICE) failed:
+        function not implemented: unknown.
+ERRO[0011] error waiting for container: context canceled
+```
+
+Upstream-Status: Pending
+
+Signed-off-by: Haseeb Ashraf <haseeb_ashraf@mentor.com>
+---
+ cfg/docker.cfg | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/cfg/docker.cfg b/cfg/docker.cfg
+index 4d8d7e04a..6bb25fd8a 100644
+--- a/cfg/docker.cfg
++++ b/cfg/docker.cfg
+@@ -12,4 +12,5 @@ CONFIG_NETFILTER_XT_MATCH_IPVS=m
+ 
+ CONFIG_OVERLAY_FS=y
+ 
++CONFIG_BPF_SYSCALL=y
+ CONFIG_CGROUP_BPF=y
+-- 
+2.34.1
+

--- a/meta-flex-staging/dynamic-layers/virtualization-layer/recipes-kernel/linux/files/0002-cfg-docker.scc-include-bridge.scc-for-docker-bridge-.patch
+++ b/meta-flex-staging/dynamic-layers/virtualization-layer/recipes-kernel/linux/files/0002-cfg-docker.scc-include-bridge.scc-for-docker-bridge-.patch
@@ -1,0 +1,30 @@
+From 79297e208e8d9be2bfd59524150e5d97dd2a53d9 Mon Sep 17 00:00:00 2001
+From: Haseeb Ashraf <haseeb_ashraf@mentor.com>
+Date: Wed, 4 Dec 2024 10:33:54 +0500
+Subject: [PATCH 2/2] cfg/docker.scc: include bridge.scc for docker bridge
+ network
+
+dockerd is failing to load modules "bridge br_netfilter". Include
+bridge.scc as required for docker bridge network support.
+
+Upstream-Status: Pending
+
+Signed-off-by: Haseeb Ashraf <haseeb_ashraf@mentor.com>
+---
+ cfg/docker.scc | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/cfg/docker.scc b/cfg/docker.scc
+index e317456cb..4f1eba249 100644
+--- a/cfg/docker.scc
++++ b/cfg/docker.scc
+@@ -1,4 +1,6 @@
+ define KFEATURE_DESCRIPTION "Enable Features needed by docker in addition to LXC features"
+ define KFEATURE_COMPATIBILITY board
+ 
++include cfg/net/bridge.scc
++
+ kconf non-hardware docker.cfg
+-- 
+2.34.1
+

--- a/meta-flex-staging/dynamic-layers/virtualization-layer/recipes-kernel/linux/yocto-cfg-fragments.bbappend
+++ b/meta-flex-staging/dynamic-layers/virtualization-layer/recipes-kernel/linux/yocto-cfg-fragments.bbappend
@@ -1,0 +1,9 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# SPDX-License-Identifier: MIT
+# ---------------------------------------------------------------------------------------------------------------------
+
+FILESEXTRAPATHS:prepend:feature-flex-staging := "${THISDIR}/files:"
+
+SRC_URI:append:feature-flex-staging = " file://0001-cfg-docker.cfg-enable-CONFIG_BPF_SYSCALL.patch \
+                                        file://0002-cfg-docker.scc-include-bridge.scc-for-docker-bridge-.patch \
+"


### PR DESCRIPTION
Adds following two patches for yocto-cfg-fragments:

1. cfg/docker.cfg: enable CONFIG_BPF_SYSCALL

CONFIG_CGROUPS_BPF depends on CONFIG_BPF_SYSCALL. If the latter is not enabled in defconfig, then CONFIG_CGROUPS_BPF is not actually enabled and results in error:
```
docker: Error response from daemon:
        failed to create task for container:
        failed to create shim task:
        OCI runtime create failed:
        runc create failed:
        unable to start container process:
        error during container init:
        error setting cgroup config for procHooks process:
        bpf_prog_query(BPF_CGROUP_DEVICE) failed:
        function not implemented: unknown.
ERRO[0011] error waiting for container: context canceled
```

2. cfg/docker.scc: include bridge.scc for docker bridge network

dockerd is failing to load modules "bridge br_netfilter". Include bridge.scc as required for docker bridge network support.

JIRA-ID: SB-23974