### PR TITLE
flex-os.conf: virtualization: increase extra-space in rootfs

### DIFF
--- a/meta-flex-distro/conf/distro/flex-os.conf
+++ b/meta-flex-distro/conf/distro/flex-os.conf
@@ -205,8 +205,8 @@ SYSTEMD_DEFAULT_TARGET ?= '${@bb.utils.contains_any("IMAGE_FEATURES", ["x11-base
 # Prefer docker-moby to docker-ce by default
 PREFERRED_PROVIDER_virtual/docker = "docker-moby"
 
-# Add extra-space to rootfs (default: 204800KB) for virtualization
-IMAGE_ROOTFS_EXTRA_SPACE:append = "${@bb.utils.contains('DISTRO_FEATURES', 'virtualization', ' + 307200', '', d)}"
+# Add extra-space to rootfs (default: 716800KB) for virtualization in absence of flex-ewaol-baremetal
+IMAGE_ROOTFS_EXTRA_SPACE:append:feature-virtualization = "${@bb.utils.contains('USER_FEATURES', 'flex-ewaol-baremetal', '', ' + 716800', d)}"
 
 # Additional package groups
 #


### PR DESCRIPTION
300M is not sufficient for container tracing validation so we need
to have atleast 700M in rootfs. So, incresing rootfs to 700M.

Moreover changed the condition to add space to rootfs only when
virtualization feature is enabled in absence of ewaol feature
because CASSINI_ROOTFS_EXTRA_SPACE add enough space in case ewaol
feature is enabled.

JIRA-ID: SB-23878