### PR TITLE
scripts: use /etc/os-release instead of lsb_release

### DIFF
--- a/scripts/build-setup-environment.in
+++ b/scripts/build-setup-environment.in
@@ -18,7 +18,7 @@ if [ -z "$OEINIT" ]; then
 else
     . "$OEINIT" "$BUILDDIR" "@BITBAKEDIR@"
     export BB_ENV_PASSTHROUGH_ADDITIONS="$BB_ENV_PASSTHROUGH_ADDITIONS GIT_SSL_CAINFO SALT_LICENSE_SERVER SALT_EXCLUDE_LICENSES SALT_INCLUDE_LICENSES SALT_LOGGING_DIR SALT_PKGINFO_FILE SALT_LICENSE_SOURCE WSL_INTEROP"
-    if lsb_release -ds | grep -Pq '(?:Red Hat Enterprise|Rocky) Linux release 8'; then
+    if grep -Pq '^ID="(?:rhel|rocky)"' /etc/os-release && grep -Pq '^VERSION_ID="8.*"' /etc/os-release; then
         # since gcc-toolset-9 also sets up its make (make42), so enable make43 after gcc-toolset-9
         . scl_source enable gcc-toolset-9
         . scl_source enable make43

--- a/scripts/setup-rh
+++ b/scripts/setup-rh
@@ -16,7 +16,7 @@ packages="python39 \
           rsync rpcgen \
           zstd lz4"
 
-if lsb_release -ds | grep -Pq '(?:Red Hat Enterprise|Rocky) Linux release 8'; then
+if grep -Pq '^ID="(?:rhel|rocky)"' /etc/os-release && grep -Pq '^VERSION_ID="8.*"' /etc/os-release; then
     # Following packages require sourcing their environment which is done through
     # setup-environment script:
     # - `source scl_source enable gcc-toolset-9`
@@ -40,9 +40,10 @@ fi
 # Enable required repo's to get install rpcgen package
 
 echo "Enabling any required repos"
-if [ `lsb_release -is` = 'RedHatEnterprise' ]; then
-    subscription-manager repos --enable "codeready-builder-for-rhel-`lsb_release -rs | cut -d. -f1`-`arch`-rpms"
-elif [ `lsb_release -is` = 'Rocky' ]; then
+if grep -Pq '^ID="rhel"' /etc/os-release; then
+    ver_id=`grep -Po '^VERSION_ID="\K[0-9]+(?=\.)' /etc/os-release`
+    subscription-manager repos --enable "codeready-builder-for-rhel-${ver_id}-`arch`-rpms"
+elif grep -Pq '^ID="rocky"' /etc/os-release; then
     dnf config-manager --set-enabled powertools
 fi
 
@@ -53,7 +54,7 @@ dnf install --assumeyes "$@" $packages || {
 }
 
 # Add symbolic link for the required version of python on following OS releases
-if lsb_release -ds | grep -Pq '(?:Red Hat Enterprise|Rocky) Linux release 8'; then
+if grep -Pq '^ID="(?:rhel|rocky)"' /etc/os-release && grep -Pq '^VERSION_ID="8.*"' /etc/os-release; then
     ln -sfn /usr/bin/python3.9 /usr/local/bin/python3
 fi
 


### PR DESCRIPTION
lsb_release requires installation of lsb-release package on fresh setups. As we can achieve the same functionality from /etc/os-release so we should drop the use of lsb_release and avoid installation of extra package.

JIRA-ID: SB-24023