### PR TITLE
llvm_19.1.6: port latest LLVM version and fix the cross-compilation config LLVM_HOST_TRIPLE

### DIFF
--- a/meta-flex-distro/recipes-devtools/llvm/llvm/0001-AsmMatcherEmitter-sort-ClassInfo-lists-by-name-as-we.patch
+++ b/meta-flex-distro/recipes-devtools/llvm/llvm/0001-AsmMatcherEmitter-sort-ClassInfo-lists-by-name-as-we.patch
@@ -1,0 +1,31 @@
+From 3b30a9bda88374e8f03bf96e972aee5bd214b98b Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Fri, 27 Nov 2020 10:11:08 +0000
+Subject: [PATCH] AsmMatcherEmitter: sort ClassInfo lists by name as well
+
+Otherwise, there are instances which are identical in
+every other field and therefore sort non-reproducibly
+(which breaks binary and source reproducibiliy).
+
+Upstream-Status: Submitted [https://reviews.llvm.org/D97477]
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+---
+ llvm/utils/TableGen/AsmMatcherEmitter.cpp | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/llvm/utils/TableGen/AsmMatcherEmitter.cpp b/llvm/utils/TableGen/AsmMatcherEmitter.cpp
+index 73724e662f9e..1ca9c73415db 100644
+--- a/llvm/utils/TableGen/AsmMatcherEmitter.cpp
++++ b/llvm/utils/TableGen/AsmMatcherEmitter.cpp
+@@ -361,7 +361,10 @@ public:
+     // name of a class shouldn't be significant. However, some of the backends
+     // accidentally rely on this behaviour, so it will have to stay like this
+     // until they are fixed.
+-    return ValueName < RHS.ValueName;
++    if (ValueName != RHS.ValueName)
++        return ValueName < RHS.ValueName;
++    // All else being equal, we should sort by name, for source and binary reproducibility
++    return Name < RHS.Name;
+   }
+ };
+ 

--- a/meta-flex-distro/recipes-devtools/llvm/llvm/0007-llvm-allow-env-override-of-exe-path.patch
+++ b/meta-flex-distro/recipes-devtools/llvm/llvm/0007-llvm-allow-env-override-of-exe-path.patch
@@ -1,0 +1,37 @@
+From 588a8694c6540e31140c7e242bfb5e279d6ca08c Mon Sep 17 00:00:00 2001
+From: Martin Kelly <mkelly@xevo.com>
+Date: Fri, 19 May 2017 00:22:57 -0700
+Subject: [PATCH] llvm: allow env override of exe and libdir path
+
+When using a native llvm-config from inside a sysroot, we need llvm-config to
+return the libraries, include directories, etc. from inside the sysroot rather
+than from the native sysroot. Thus provide an env override for calling
+llvm-config from a target sysroot.
+
+Upstream-Status: Inappropriate [OE-specific]
+
+Signed-off-by: Martin Kelly <mkelly@xevo.com>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ llvm/tools/llvm-config/llvm-config.cpp | 25 +++++++++++++++++++------
+ 1 file changed, 19 insertions(+), 6 deletions(-)
+
+diff --git a/llvm/tools/llvm-config/llvm-config.cpp b/llvm/tools/llvm-config/llvm-config.cpp
+index e86eb2b44b10..7b2abf318dbe 100644
+--- a/llvm/tools/llvm-config/llvm-config.cpp
++++ b/llvm/tools/llvm-config/llvm-config.cpp
+@@ -246,6 +246,13 @@ Typical components:\n\
+ 
+ /// Compute the path to the main executable.
+ std::string GetExecutablePath(const char *Argv0) {
++  // Hack for Yocto: we need to override the root path when we are using
++  // llvm-config from within a target sysroot.
++  const char *Sysroot = std::getenv("YOCTO_ALTERNATE_EXE_PATH");
++  if (Sysroot != nullptr) {
++    return Sysroot;
++  }
++
+   // This just needs to be some symbol in the binary; C++ doesn't
+   // allow taking the address of ::main however.
+   void *P = (void *)(intptr_t)GetExecutablePath;
+ 

--- a/meta-flex-distro/recipes-devtools/llvm/llvm/llvm-config
+++ b/meta-flex-distro/recipes-devtools/llvm/llvm/llvm-config
@@ -1,0 +1,51 @@
+#!/bin/bash
+#
+# Copyright OpenEmbedded Contributors
+#
+# SPDX-License-Identifier: MIT
+#
+# Wrap llvm-config since the native llvm-config will remap some values correctly
+# if placed in the target sysroot but for flags, it would provide the native ones.
+# Provide ours from the environment instead.
+
+NEXT_LLVM_CONFIG="$(which -a llvm-config | sed -n 2p)"
+if [[ $# == 0 ]]; then
+  exec "$NEXT_LLVM_CONFIG"
+fi
+
+remain=""
+output=""
+for arg in "$@"; do
+  case "$arg" in
+    --cppflags)
+      output="${output} ${CPPFLAGS}"
+      ;;
+    --cflags)
+      output="${output} ${CFLAGS}"
+      ;;
+    --cxxflags)
+      output="${output} ${CXXFLAGS}"
+      ;;
+    --ldflags)
+      output="${output} ${LDFLAGS}"
+      ;;
+    --shared-mode)
+      output="${output} shared"
+      ;;
+    --libs)
+      output="${output} -lLLVM"
+      ;;
+    --link-shared)
+      break
+      ;;
+    *)
+      remain="${remain} ${arg}"
+      ;;
+  esac
+done
+
+if [ "${remain}" != "" ]; then
+      output="${output} "$("$NEXT_LLVM_CONFIG" ${remain})
+fi
+
+echo "${output}"

--- a/meta-flex-distro/recipes-devtools/llvm/llvm_19.1.6.bb
+++ b/meta-flex-distro/recipes-devtools/llvm/llvm_19.1.6.bb
@@ -1,0 +1,179 @@
+# Copyright (C) 2017 Khem Raj <raj.khem@gmail.com>
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+SUMMARY = "The LLVM Compiler Infrastructure"
+HOMEPAGE = "http://llvm.org"
+LICENSE = "Apache-2.0-with-LLVM-exception"
+SECTION = "devel"
+
+LIC_FILES_CHKSUM = "file://LICENSE.TXT;md5=8a15a0759ef07f2682d2ba4b893c9afe"
+
+DEPENDS = "libffi libxml2 zlib zstd libedit ninja-native llvm-native"
+
+RDEPENDS:${PN}:append:class-target = " ncurses-terminfo"
+
+inherit cmake pkgconfig
+# could be 'rcX' or 'git' or empty ( for release )
+VER_SUFFIX = ""
+
+PV .= "${VER_SUFFIX}"
+
+MAJOR_VERSION = "${@oe.utils.trim_version("${PV}", 1)}"
+
+LLVM_RELEASE = "${PV}"
+
+SRC_URI = "https://github.com/llvm/llvm-project/releases/download/llvmorg-${PV}/llvm-project-${PV}.src.tar.xz \
+           file://0007-llvm-allow-env-override-of-exe-path.patch;striplevel=2 \
+           file://0001-AsmMatcherEmitter-sort-ClassInfo-lists-by-name-as-we.patch;striplevel=2 \
+           file://llvm-config \
+           "
+SRC_URI[sha256sum] = "e3f79317adaa9196d2cfffe1c869d7c100b7540832bc44fe0d3f44a12861fa34"
+UPSTREAM_CHECK_URI = "https://github.com/llvm/llvm-project"
+UPSTREAM_CHECK_REGEX = "llvmorg-(?P<pver>\d+(\.\d+)+)"
+
+S = "${WORKDIR}/llvm-project-${PV}.src/llvm"
+
+LLVM_INSTALL_DIR = "${WORKDIR}/llvm-install"
+
+def get_llvm_arch(bb, d, arch_var):
+    import re
+    a = d.getVar(arch_var)
+    if   re.match(r'(i.86|athlon|x86.64)$', a):         return 'X86'
+    elif re.match(r'arm$', a):                          return 'ARM'
+    elif re.match(r'armeb$', a):                        return 'ARM'
+    elif re.match(r'aarch64$', a):                      return 'AArch64'
+    elif re.match(r'aarch64_be$', a):                   return 'AArch64'
+    elif re.match(r'mips(isa|)(32|64|)(r6|)(el|)$', a): return 'Mips'
+    elif re.match(r'riscv(32|64)(eb|)$', a):            return 'RISCV'
+    elif re.match(r'p(pc|owerpc)(|64)', a):             return 'PowerPC'
+    else:
+        raise bb.parse.SkipRecipe("Cannot map '%s' to a supported LLVM architecture" % a)
+
+def get_llvm_host_arch(bb, d):
+    return get_llvm_arch(bb, d, 'HOST_ARCH')
+
+PACKAGECONFIG ??= "libllvm"
+# if optviewer OFF, force the modules to be not found or the ones on the host would be found
+PACKAGECONFIG[optviewer] = ",-DPY_PYGMENTS_FOUND=OFF -DPY_PYGMENTS_LEXERS_C_CPP_FOUND=OFF -DPY_YAML_FOUND=OFF,python3-pygments python3-pyyaml,python3-pygments python3-pyyaml"
+PACKAGECONFIG[libllvm] = ""
+
+#
+# Default to build all OE-Core supported target arches (user overridable).
+#
+LLVM_TARGETS ?= "AMDGPU;${@get_llvm_host_arch(bb, d)}"
+
+ARM_INSTRUCTION_SET:armv5 = "arm"
+ARM_INSTRUCTION_SET:armv4t = "arm"
+
+EXTRA_OECMAKE += "-DLLVM_ENABLE_ASSERTIONS=OFF \
+                  -DLLVM_ENABLE_EXPENSIVE_CHECKS=OFF \
+                  -DLLVM_ENABLE_PIC=ON \
+                  -DLLVM_BINDINGS_LIST='' \
+                  -DLLVM_LINK_LLVM_DYLIB=ON \
+                  -DLLVM_ENABLE_FFI=ON \
+                  -DLLVM_ENABLE_RTTI=ON \
+                  -DFFI_INCLUDE_DIR=$(pkg-config --variable=includedir libffi) \
+                  -DLLVM_OPTIMIZED_TABLEGEN=ON \
+                  -DLLVM_TARGETS_TO_BUILD='${LLVM_TARGETS}' \
+                  -DLLVM_VERSION_SUFFIX='${VER_SUFFIX}' \
+                  -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=ON \
+                  -DCMAKE_BUILD_TYPE=Release \
+                 "
+
+EXTRA_OECMAKE:append:class-target = "\
+                  -DCMAKE_CROSSCOMPILING:BOOL=ON \
+                  -DLLVM_TABLEGEN=${STAGING_BINDIR_NATIVE}/llvm-tblgen${PV} \
+                  -DLLVM_CONFIG_PATH=${STAGING_BINDIR_NATIVE}/llvm-config${PV} \
+                 "
+
+EXTRA_OECMAKE:append:class-nativesdk = "\
+                  -DCMAKE_CROSSCOMPILING:BOOL=ON \
+                  -DLLVM_TABLEGEN=${STAGING_BINDIR_NATIVE}/llvm-tblgen${PV} \
+                  -DLLVM_CONFIG_PATH=${STAGING_BINDIR_NATIVE}/llvm-config${PV} \
+                 "
+
+# patch out build host paths for reproducibility
+do_compile:prepend:class-target() {
+        sed -i -e "s,${WORKDIR},,g" ${B}/tools/llvm-config/BuildVariables.inc
+}
+
+do_compile:prepend:class-nativesdk() {
+        sed -i -e "s,${WORKDIR},,g" ${B}/tools/llvm-config/BuildVariables.inc
+}
+
+do_compile() {
+    if ${@bb.utils.contains('PACKAGECONFIG', 'libllvm', 'true', 'false', d)}; then
+	ninja -v ${PARALLEL_MAKE}
+    else
+	ninja -v ${PARALLEL_MAKE} llvm-config llvm-tblgen
+    fi
+}
+
+do_install() {
+    if ${@bb.utils.contains('PACKAGECONFIG', 'libllvm', 'true', 'false', d)}; then
+	DESTDIR=${D} ninja -v install
+
+        # llvm harcodes usr/lib as install path, so this corrects it to actual libdir
+        mv -T -n ${D}/${prefix}/lib ${D}/${libdir} || true
+
+        # Remove opt-viewer: https://llvm.org/docs/Remarks.html
+        rm -rf ${D}${datadir}/opt-viewer
+        rmdir ${D}${datadir}
+
+        # reproducibility
+        sed -i -e 's,${WORKDIR},,g' ${D}/${libdir}/cmake/llvm/LLVMConfig.cmake
+    fi
+}
+
+do_install:append:class-native() {
+	install -D -m 0755 ${B}/bin/llvm-tblgen ${D}${bindir}/llvm-tblgen${PV}
+	install -D -m 0755 ${B}/bin/llvm-config ${D}${bindir}/llvm-config${PV}
+	ln -sf llvm-config${PV} ${D}${bindir}/llvm-config
+}
+
+SYSROOT_PREPROCESS_FUNCS:append:class-target = " llvm_sysroot_preprocess"
+
+llvm_sysroot_preprocess() {
+	install -d ${SYSROOT_DESTDIR}${bindir_crossscripts}/
+	install -m 0755 ${WORKDIR}/llvm-config ${SYSROOT_DESTDIR}${bindir_crossscripts}/
+	ln -sf llvm-config ${SYSROOT_DESTDIR}${bindir_crossscripts}/llvm-config${PV}
+}
+
+PACKAGES =+ "${PN}-bugpointpasses ${PN}-llvmhello ${PN}-libllvm ${PN}-liboptremarks ${PN}-liblto"
+
+RRECOMMENDS:${PN}-dev += "${PN}-bugpointpasses ${PN}-llvmhello ${PN}-liboptremarks"
+
+FILES:${PN}-bugpointpasses = "\
+    ${libdir}/BugpointPasses.so \
+"
+
+FILES:${PN}-libllvm = "\
+    ${libdir}/libLLVM-${MAJOR_VERSION}.so \
+    ${libdir}/libLLVM.so.${MAJOR_VER}.${MINOR_VER} \
+"
+
+FILES:${PN}-liblto += "\
+    ${libdir}/libLTO.so.* \
+"
+
+FILES:${PN}-liboptremarks += "\
+    ${libdir}/libRemarks.so.* \
+"
+
+FILES:${PN}-llvmhello = "\
+    ${libdir}/LLVMHello.so \
+"
+
+FILES:${PN}-dev += " \
+    ${libdir}/llvm-config \
+    ${libdir}/libRemarks.so \
+    ${libdir}/libLLVM-${PV}.so \
+"
+
+FILES:${PN}-staticdev += "\
+    ${libdir}/*.a \
+"
+
+INSANE_SKIP:${PN}-libllvm += "dev-so"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-flex-staging/recipes-devtools/llvm/llvm_%.bbappend
+++ b/meta-flex-staging/recipes-devtools/llvm/llvm_%.bbappend
@@ -1,0 +1,6 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# SPDX-License-Identifier: MIT
+# ---------------------------------------------------------------------------------------------------------------------
+
+EXTRA_OECMAKE:append:class-target = " -DLLVM_HOST_TRIPLE=${TARGET_SYS}"
+EXTRA_OECMAKE:append:class-nativesdk = " -DLLVM_HOST_TRIPLE=${SDK_SYS}"


### PR DESCRIPTION
We are experiencing issue with EGL initialization. As mesa depends on LLVM for llvmpipe driver, so porting the latest version available as of today which seems to fix the issue.
Ported from:
https://github.com/openembedded/openembedded-core/commit/8546473f724e16095e8ad68813f3a087cb1b2779

Tested-by: Ahsan Hussain <ahsan.hussain@siemens.com>
Signed-off-by: Haseeb Ashraf <haseeb_ashraf@mentor.com>

The correct way to configure cmake for cross-compilation includes setting the LLVM_HOST_TRIPLE as well. This fixes the bug when LLVM is cross-compiled for AAarch64 but it was getting built with the triple of native build system instead of the TARGET_SYS ('aarch64-oe-linux' in my case).
```
No available targets are compatible with triple "x86_64-unknown-linux-gnu"
```
Documentation Ref:
https://github.com/llvm/llvm-project/blob/llvmorg-19.1.6/llvm/docs/HowToCrossCompileLLVM.rst#configuring-cmake

JIRA-ID: SB-24074

Signed-off-by: Haseeb Ashraf <haseeb_ashraf@mentor.com>