### PR TITLE
innexis-linux: remove glmark2-es2-drm benchmark from RFS

### DIFF
--- a/meta-flex-distro/conf/distro/innexis-linux.conf
+++ b/meta-flex-distro/conf/distro/innexis-linux.conf
@@ -345,6 +345,10 @@ PACKAGECONFIG:append:pn-mesa = " gallium-llvm"
 PACKAGECONFIG:pn-vulkan-cts = "surfaceless"
 PACKAGECONFIG:pn-vulkan-examples = "headless"
 
+# Currently our supported GPUs do not have async page flipping DRM
+# capability; without this the glmark2-es2-drm can report low performance
+# numbers which are misleading. Remove it from the RFS
+PACKAGECONFIG:remove:pn-glmark2 = "drm-gles2"
 
 ## }}}1
 # vim: set fdm=marker fdl=0 :


### PR DESCRIPTION
For details, see:
https://jira.alm.mentorg.com/browse/SB-24084?focusedId=983599&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-983599

JIRA-ID: SB-24084, SB-24103