### PR TITLE
staging: lttng-modules_2.13.9: add fix for build with kernel >= v5.15.171

### DIFF
--- a/meta-sokol-flex-staging/recipes-kernel/lttng/lttng-modules/0001-fix-mm-page_alloc-fix-tracepoint-mm_page_alloc_zone_.patch
+++ b/meta-sokol-flex-staging/recipes-kernel/lttng/lttng-modules/0001-fix-mm-page_alloc-fix-tracepoint-mm_page_alloc_zone_.patch
@@ -1,0 +1,60 @@
+From 9bea5b7ccb27b0354d1eb4779062a55469a81822 Mon Sep 17 00:00:00 2001
+From: Michael Jeanson <mjeanson@efficios.com>
+Date: Tue, 12 Nov 2024 11:19:23 -0500
+Subject: [PATCH 1/1] fix: mm/page_alloc: fix tracepoint
+ mm_page_alloc_zone_locked() (v5.15.171)
+
+See upstream backported commit:
+
+  commit 28e7a507196fefd119e7ca2286840f1a9aad5e8a
+  Author: Wonhyuk Yang <vvghjk1234@gmail.com>
+  Date:   Thu May 19 14:08:54 2022 -0700
+
+    mm/page_alloc: fix tracepoint mm_page_alloc_zone_locked()
+
+    [ Upstream commit 10e0f7530205799e7e971aba699a7cb3a47456de ]
+
+    Currently, trace point mm_page_alloc_zone_locked() doesn't show correct
+    information.
+
+    First, when alloc_flag has ALLOC_HARDER/ALLOC_CMA, page can be allocated
+    from MIGRATE_HIGHATOMIC/MIGRATE_CMA.  Nevertheless, tracepoint use
+    requested migration type not MIGRATE_HIGHATOMIC and MIGRATE_CMA.
+
+    Second, after commit 44042b4498728 ("mm/page_alloc: allow high-order pages
+    to be stored on the per-cpu lists") percpu-list can store high order
+    pages.  But trace point determine whether it is a refiil of percpu-list by
+    comparing requested order and 0.
+
+    To handle these problems, make mm_page_alloc_zone_locked() only be called
+    by __rmqueue_smallest with correct migration type.  With a new argument
+    called percpu_refill, it can show roughly whether it is a refill of
+    percpu-list.
+
+    Link: https://lkml.kernel.org/r/20220512025307.57924-1-vvghjk1234@gmail.com
+
+Change-Id: Ib76feb79d95e9f93c84c3aa1b946e57ac2e2666a
+Signed-off-by: Michael Jeanson <mjeanson@efficios.com>
+Signed-off-by: Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
+---
+ include/instrumentation/events/kmem.h | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/include/instrumentation/events/kmem.h b/include/instrumentation/events/kmem.h
+index aa9c98d1..8acd8298 100644
+--- a/include/instrumentation/events/kmem.h
++++ b/include/instrumentation/events/kmem.h
+@@ -376,7 +376,9 @@ LTTNG_TRACEPOINT_EVENT_MAP(mm_page_alloc, kmem_mm_page_alloc,
+ 	)
+ )
+ 
+-#if (LTTNG_LINUX_VERSION_CODE >= LTTNG_KERNEL_VERSION(5,19,0))
++#if (LTTNG_LINUX_VERSION_CODE >= LTTNG_KERNEL_VERSION(5,19,0) || \
++	LTTNG_KERNEL_RANGE(5,15,171, 5,16,0))
++
+ LTTNG_TRACEPOINT_EVENT_CLASS(kmem_mm_page,
+ 
+ 	TP_PROTO(struct page *page, unsigned int order, int migratetype,
+-- 
+2.34.1
+

--- a/meta-sokol-flex-staging/recipes-kernel/lttng/lttng-modules_2.13.9.bbappend
+++ b/meta-sokol-flex-staging/recipes-kernel/lttng/lttng-modules_2.13.9.bbappend
@@ -1,0 +1,9 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# SPDX-License-Identifier: MIT
+# ---------------------------------------------------------------------------------------------------------------------
+
+FILESEXTRAPATHS:prepend:feature-sokol-flex-staging := "${THISDIR}/lttng-modules:"
+
+SRC_URI:append:feature-sokol-flex-staging = "\
+    file://0001-fix-mm-page_alloc-fix-tracepoint-mm_page_alloc_zone_.patch \
+"


### PR DESCRIPTION
This fixes a build failure when lttng-modules are compiled with kernel
version >= 5.15.171. The definition of tracepoint `mm_page_alloc_zone_locked`
is available in kernel version 5.15.171 which causes a conflict with the 
definition available in lttng-modules.

Ref: https://github.com/lttng/lttng-modules/commit/25401cbde2a2a560f20fdd87fc0562339e9da689