### PR TITLE
Support build on Ubuntu-24 host

### DIFF
--- a/meta-flex-distro/conf/distro/innexis-linux.conf
+++ b/meta-flex-distro/conf/distro/innexis-linux.conf
@@ -62,10 +62,8 @@ PACKAGE_CLASSES ?= "package_ipk"
 # Innexis Linux's supported hosts
 SANITY_TESTED_DISTROS = "\
     ubuntu-22.04 \n\
-    rhel*-8* \n \
+    ubuntu-24.04 \n\
     rocky*-8* \n \
-    rhel*-9* \n \
-    redhatenterprise*-9* \n \
 "
 
 # Remove MACHINE from default volname

--- a/scripts/build-setup-environment.in
+++ b/scripts/build-setup-environment.in
@@ -23,6 +23,9 @@ else
         . scl_source enable gcc-toolset-9
         . scl_source enable make43
     fi
+    if grep -Pq '^ID=(?:|")ubuntu(?:|")' /etc/os-release && grep -Pq '^VERSION_ID=(?:|")24\.' /etc/os-release; then
+        umask 0022
+    fi
     unset TEMPLATECONF OEINIT
     cd "$BUILDDIR"
     command -v bitbake >/dev/null 2>&1

--- a/scripts/build-setup-environment.in
+++ b/scripts/build-setup-environment.in
@@ -18,7 +18,7 @@ if [ -z "$OEINIT" ]; then
 else
     . "$OEINIT" "$BUILDDIR" "@BITBAKEDIR@"
     export BB_ENV_PASSTHROUGH_ADDITIONS="$BB_ENV_PASSTHROUGH_ADDITIONS GIT_SSL_CAINFO SALT_LICENSE_SERVER SALT_EXCLUDE_LICENSES SALT_INCLUDE_LICENSES SALT_LOGGING_DIR SALT_PKGINFO_FILE SALT_LICENSE_SOURCE WSL_INTEROP"
-    if grep -Pq '^ID="(?:rhel|rocky)"' /etc/os-release && grep -Pq '^VERSION_ID="8.*"' /etc/os-release; then
+    if grep -Pq '^ID=(?:|")rocky(?:|")' /etc/os-release && grep -Pq '^VERSION_ID=(?:|")8\.' /etc/os-release; then
         # since gcc-toolset-9 also sets up its make (make42), so enable make43 after gcc-toolset-9
         . scl_source enable gcc-toolset-9
         . scl_source enable make43

--- a/scripts/setup-rocky
+++ b/scripts/setup-rocky
@@ -16,7 +16,7 @@ packages="python39 \
           rsync rpcgen \
           zstd lz4"
 
-if grep -Pq '^VERSION_ID="8.*"' /etc/os-release; then
+if grep -Pq '^VERSION_ID=(?:|")8\.' /etc/os-release; then
     # Following packages require sourcing their environment which is done through
     # setup-environment script:
     # - `source scl_source enable gcc-toolset-9`
@@ -37,7 +37,7 @@ if [ "$(id -u)" != "0" ]; then
     exec sudo "$0" "$@"
 fi
 
-if ! grep -Pq '^ID="rocky"' /etc/os-release; then
+if ! grep -Pq '^ID=(?:|")rocky(?:|")' /etc/os-release; then
     echo "This script is for Rocky OS only, aborting"
     exit 1
 fi
@@ -53,7 +53,7 @@ dnf install --assumeyes "$@" $packages || {
 }
 
 # Add symbolic link for the required version of python on Rocky-8
-if grep -Pq '^VERSION_ID="8.*"' /etc/os-release; then
+if grep -Pq '^VERSION_ID=(?:|")8\.' /etc/os-release; then
     ln -sfn /usr/bin/python3.9 /usr/local/bin/python3
 fi
 

--- a/scripts/setup-ubuntu
+++ b/scripts/setup-ubuntu
@@ -42,4 +42,21 @@ fi
 echo "Generating the en_US.UTF-8 locale"
 $SUDO locale-gen en_US.UTF-8
 
+# Workaround for ubuntu-24 issue [Allow bitbake to create user namespace](https://bugs.launchpad.net/ubuntu/+source/apparmor/+bug/2056555)
+if grep -Pq '^VERSION_ID=(?:|")24\.' /etc/os-release; then
+    echo "Adding Bitbake's AppArmor Profile to associate it with User Namespace profile"
+    echo "NOTE: This is a workaround for Ubuntu bug (https://bugs.launchpad.net/ubuntu/+source/apparmor/+bug/2056555)"
+    echo "which gives unconfined access to bitbake binary. You may review the AppArmor Profile for Bitbake available"
+    echo "here: /etc/apparmor.d/bitbake"
+    $SUDO tee /etc/apparmor.d/bitbake > /dev/null <<'EOF'
+abi <abi/4.0>,
+include <tunables/global>
+profile bitbake /**/bitbake/bin/bitbake flags=(unconfined) {
+        userns,
+}
+EOF
+    # Reload AppArmor Profile
+    $SUDO apparmor_parser -r /etc/apparmor.d/bitbake
+fi
+
 echo "Setup complete"


### PR DESCRIPTION
* innexis-linux: update list of supported hosts
We decommissioned support for Redhat hosts and added support for Ubuntu-24 host for Innexis Linux builds.
* scripts/setup-ubuntu: add fix/workaround for build on ubuntu-24 host
Ubuntu-24 enables apparmor by-default which restricts the permissions for bitbake binary. No proper solution is available as of today, see the discussion here:
https://bugs.launchpad.net/ubuntu/+source/apparmor/+bug/2056555
Secondly, Ubuntu-24 uses UMASK 0027 as default now instead of 0022 but oe-core's sanity requires 0022:
https://github.com/openembedded/openembedded-core/blob/yocto-5.0.3/meta/classes-global/sanity.bbclass#L842
* scripts: update regex for matching ID and VERSION_ID in os-release
Ignore the double quote (") while matching ID or VERSION_ID, and check version until dot is matched.

JIRA-ID: SB-24317

Signed-off-by: Haseeb Ashraf <haseeb_ashraf@mentor.com>
