### PR TITLE
mesa: fix vkmark related issues

### DIFF
--- a/meta-flex-staging/recipes-graphics/mesa/files/0001-llvmpipe-Disable-anisotropic-filtering-for-explicit-.patch
+++ b/meta-flex-staging/recipes-graphics/mesa/files/0001-llvmpipe-Disable-anisotropic-filtering-for-explicit-.patch
@@ -1,0 +1,28 @@
+From 1196559d894abcfa31e0c28281206aaa7ac496a1 Mon Sep 17 00:00:00 2001
+From: Konstantin Seurer <konstantin.seurer@gmail.com>
+Date: Fri, 27 Dec 2024 13:17:38 +0100
+Subject: [PATCH 1/9] llvmpipe: Disable anisotropic filtering for explicit lod
+
+Reviewed-by: Adam Jackson <ajax@redhat.com>
+Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/31748>
+
+Upstream-Status: Backport [https://gitlab.freedesktop.org/mesa/mesa/-/commit/7279e47521bd6fe885c734f4d6e7d53fb74d7279]
+---
+ src/gallium/auxiliary/gallivm/lp_bld_sample_soa.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/gallium/auxiliary/gallivm/lp_bld_sample_soa.c b/src/gallium/auxiliary/gallivm/lp_bld_sample_soa.c
+index 224f8d29b45..47412f380c2 100644
+--- a/src/gallium/auxiliary/gallivm/lp_bld_sample_soa.c
++++ b/src/gallium/auxiliary/gallivm/lp_bld_sample_soa.c
+@@ -3508,6 +3508,7 @@ lp_build_sample_soa_code(struct gallivm_state *gallivm,
+       assert(derivs == NULL);
+    } else if (lod_control == LP_SAMPLER_LOD_EXPLICIT) {
+       explicit_lod = lod;
++      derived_sampler_state.aniso = 0;
+       assert(lod);
+       assert(derivs == NULL);
+    } else if (lod_control == LP_SAMPLER_LOD_DERIVATIVES) {
+-- 
+2.34.1
+

--- a/meta-flex-staging/recipes-graphics/mesa/files/0001-util-add-c-guards-to-u_mm.h.patch
+++ b/meta-flex-staging/recipes-graphics/mesa/files/0001-util-add-c-guards-to-u_mm.h.patch
@@ -1,0 +1,45 @@
+From 45edcc1c6ae54e30e15b987f214e9428f2e6e7aa Mon Sep 17 00:00:00 2001
+From: Gurchetan Singh <gurchetansingh@google.com>
+Date: Fri, 1 Nov 2024 14:53:39 -0700
+Subject: [PATCH 1/2] util: add c++ guards to u_mm.h
+
+Needed for gfxstream.
+
+Reviewed-by: Marcin Radomski <dextero@google.com>
+Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/32015>
+
+Upstream-Status: Backport [https://gitlab.freedesktop.org/mesa/mesa/-/commit/5d299a0bd44caa66ccde65369e743c8ba0a9b7cf]
+---
+ src/util/u_mm.h | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/src/util/u_mm.h b/src/util/u_mm.h
+index 66886febf4c..62f234f987a 100644
+--- a/src/util/u_mm.h
++++ b/src/util/u_mm.h
+@@ -29,10 +29,12 @@
+  * heaps, etc.
+  */
+ 
+-
+ #ifndef _U_MM_H_
+ #define _U_MM_H_
+ 
++#ifdef __cplusplus
++extern "C" {
++#endif
+ 
+ struct mem_block {
+    struct mem_block *next, *prev;
+@@ -88,4 +90,8 @@ extern void u_mmDestroy(struct mem_block *mmInit);
+  */
+ extern void u_mmDumpMemInfo(const struct mem_block *mmInit);
+ 
++#ifdef __cplusplus
++}
++#endif
++
+ #endif
+-- 
+2.34.1
+

--- a/meta-flex-staging/recipes-graphics/mesa/files/0002-gfxstream-nuke-android-base-SubAllocator.patch
+++ b/meta-flex-staging/recipes-graphics/mesa/files/0002-gfxstream-nuke-android-base-SubAllocator.patch
@@ -1,0 +1,127 @@
+From 9e6058e84b1c1d21eb828d35a211380929e43e38 Mon Sep 17 00:00:00 2001
+From: Gurchetan Singh <gurchetansingh@google.com>
+Date: Fri, 1 Nov 2024 16:26:49 -0700
+Subject: [PATCH 2/2] gfxstream: nuke android::base::SubAllocator
+
+Use u_mm, one less dependency on libaemu v0.1.2
+
+Reviewed-by: Marcin Radomski <dextero@google.com>
+Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/32015>
+
+Upstream-Status: Backport [https://gitlab.freedesktop.org/mesa/mesa/-/commit/dd5244e6ac1366e4cd464e8b7548e0fc14ca281d]
+---
+ .../HostVisibleMemoryVirtualization.cpp       | 29 ++++++++++---------
+ .../HostVisibleMemoryVirtualization.h         | 11 +++----
+ 2 files changed, 22 insertions(+), 18 deletions(-)
+
+diff --git a/src/gfxstream/guest/vulkan_enc/HostVisibleMemoryVirtualization.cpp b/src/gfxstream/guest/vulkan_enc/HostVisibleMemoryVirtualization.cpp
+index 68a8fb20380..eed6f9a96a7 100644
+--- a/src/gfxstream/guest/vulkan_enc/HostVisibleMemoryVirtualization.cpp
++++ b/src/gfxstream/guest/vulkan_enc/HostVisibleMemoryVirtualization.cpp
+@@ -9,9 +9,6 @@
+ #include "ResourceTracker.h"
+ #include "Resources.h"
+ #include "VkEncoder.h"
+-#include "aemu/base/SubAllocator.h"
+-
+-using android::base::SubAllocator;
+ 
+ namespace gfxstream {
+ namespace vk {
+@@ -23,38 +20,44 @@ bool isHostVisible(const VkPhysicalDeviceMemoryProperties* memoryProps, uint32_t
+ CoherentMemory::CoherentMemory(VirtGpuResourceMappingPtr blobMapping, uint64_t size,
+                                VkDevice device, VkDeviceMemory memory)
+     : mSize(size), mBlobMapping(blobMapping), mDevice(device), mMemory(memory) {
+-    mAllocator =
+-        std::make_unique<android::base::SubAllocator>(blobMapping->asRawPtr(), mSize, 4096);
++    mHeap = u_mmInit(0, kHostVisibleHeapSize);
++    mBaseAddr = blobMapping->asRawPtr();
+ }
+ 
+ #if defined(__ANDROID__)
+ CoherentMemory::CoherentMemory(GoldfishAddressSpaceBlockPtr block, uint64_t gpuAddr, uint64_t size,
+                                VkDevice device, VkDeviceMemory memory)
+     : mSize(size), mBlock(block), mDevice(device), mMemory(memory) {
+-    void* address = block->mmap(gpuAddr);
+-    mAllocator = std::make_unique<android::base::SubAllocator>(address, mSize, kLargestPageSize);
++    mHeap = u_mmInit(0, kHostVisibleHeapSize);
++    mBaseAddr = (uint8_t*)block->mmap(gpuAddr);
+ }
+ #endif  // defined(__ANDROID__)
+ 
+ CoherentMemory::~CoherentMemory() {
+     ResourceTracker::getThreadLocalEncoder()->vkFreeMemorySyncGOOGLE(mDevice, mMemory, nullptr,
+                                                                      false);
++    u_mmDestroy(mHeap);
+ }
+ 
+ VkDeviceMemory CoherentMemory::getDeviceMemory() const { return mMemory; }
+ 
+ bool CoherentMemory::subAllocate(uint64_t size, uint8_t** ptr, uint64_t& offset) {
+-    auto address = mAllocator->alloc(size);
+-    if (!address) return false;
++    auto block = u_mmAllocMem(mHeap, (int)size, 0, 0);
++    if (!block) return false;
+ 
+-    *ptr = (uint8_t*)address;
+-    offset = mAllocator->getOffset(address);
++    *ptr = mBaseAddr + block->ofs;
+     return true;
+ }
+ 
+ bool CoherentMemory::release(uint8_t* ptr) {
+-    mAllocator->free(ptr);
+-    return true;
++    int offset = ptr - mBaseAddr;
++    auto block = u_mmFindBlock(mHeap, offset);
++    if (block) {
++        u_mmFreeMem(block);
++        return true;
++    }
++
++    return false;
+ }
+ 
+ }  // namespace vk
+diff --git a/src/gfxstream/guest/vulkan_enc/HostVisibleMemoryVirtualization.h b/src/gfxstream/guest/vulkan_enc/HostVisibleMemoryVirtualization.h
+index ac3c46490c2..c71abf2309f 100644
+--- a/src/gfxstream/guest/vulkan_enc/HostVisibleMemoryVirtualization.h
++++ b/src/gfxstream/guest/vulkan_enc/HostVisibleMemoryVirtualization.h
+@@ -7,8 +7,8 @@
+ #include <vulkan/vulkan.h>
+ 
+ #include "VirtGpu.h"
+-#include "aemu/base/SubAllocator.h"
+ #include "goldfish_address_space.h"
++#include "util/u_mm.h"
+ 
+ constexpr uint64_t kMegaByte = 1048576;
+ 
+@@ -27,7 +27,6 @@ namespace vk {
+ bool isHostVisible(const VkPhysicalDeviceMemoryProperties* memoryProps, uint32_t index);
+ 
+ using GoldfishAddressSpaceBlockPtr = std::shared_ptr<GoldfishAddressSpaceBlock>;
+-using SubAllocatorPtr = std::unique_ptr<android::base::SubAllocator>;
+ 
+ class CoherentMemory {
+    public:
+@@ -51,11 +50,13 @@ class CoherentMemory {
+     void operator=(CoherentMemory const&);
+ 
+     uint64_t mSize;
+-    VirtGpuResourceMappingPtr mBlobMapping = nullptr;
+-    GoldfishAddressSpaceBlockPtr mBlock = nullptr;
++    VirtGpuResourceMappingPtr mBlobMapping;
++    GoldfishAddressSpaceBlockPtr mBlock;
+     VkDevice mDevice;
+     VkDeviceMemory mMemory;
+-    SubAllocatorPtr mAllocator;
++
++    uint8_t* mBaseAddr = nullptr;
++    struct mem_block* mHeap = nullptr;
+ };
+ 
+ using CoherentMemoryPtr = std::shared_ptr<CoherentMemory>;
+-- 
+2.34.1
+

--- a/meta-flex-staging/recipes-graphics/mesa/files/0002-llvmpipe-Use-a-simpler-and-faster-AF-implementation.patch
+++ b/meta-flex-staging/recipes-graphics/mesa/files/0002-llvmpipe-Use-a-simpler-and-faster-AF-implementation.patch
@@ -1,0 +1,531 @@
+From 68cb09c92b84fd1a468b10b43db3e1fcb522bc4e Mon Sep 17 00:00:00 2001
+From: Konstantin Seurer <konstantin.seurer@gmail.com>
+Date: Thu, 17 Oct 2024 21:32:09 +0200
+Subject: [PATCH 2/9] llvmpipe: Use a simpler and faster AF implementation
+
+This is based on the example given by the Vulkan specification: https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#textures-texel-anisotropic-filtering
+
+The basic idea is to compute the axis in which the uv coordinates
+change the fastest in screen space (rho_y and rho_y). If rho_x is larger
+than rho_y, samples are summed up along the x-Axis and the y-Axis
+viceversa. The x/y offsets are mapped back into texture (u/v) space
+using a linear approximation of u(x,y) and v(x,y).
+
+This approach does not use a nested loop and the number of samples is
+basically limited to max_anisotropy (+/-). The sample count of the
+previous approach could explode in some situations, leading to
+frametimes >1s.
+
+Reviewed-by: Aleksi Sapon <aleksi.sapon@autodesk.com>
+Reviewed-by: Adam Jackson <ajax@redhat.com>
+Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/31748>
+
+Upstream-Status: Backport [https://gitlab.freedesktop.org/mesa/mesa/-/commit/350a0fe63298d72593c473a0aae83afcd84de9b8]
+---
+ .../auxiliary/gallivm/lp_bld_sample_soa.c     | 455 +++---------------
+ .../drivers/llvmpipe/ci/traces-llvmpipe.yml   |   6 +-
+ 2 files changed, 75 insertions(+), 386 deletions(-)
+
+diff --git a/src/gallium/auxiliary/gallivm/lp_bld_sample_soa.c b/src/gallium/auxiliary/gallivm/lp_bld_sample_soa.c
+index 47412f380c2..ec825ca342e 100644
+--- a/src/gallium/auxiliary/gallivm/lp_bld_sample_soa.c
++++ b/src/gallium/auxiliary/gallivm/lp_bld_sample_soa.c
+@@ -2200,15 +2200,7 @@ lp_build_sample_aniso(struct lp_build_sample_context *bld,
+    struct gallivm_state *gallivm = bld->gallivm;
+    LLVMBuilderRef builder = gallivm->builder;
+    struct lp_build_context *coord_bld = &bld->coord_bld;
+-   struct lp_build_context *float_size_bld = &bld->float_size_in_bld;
+-   LLVMValueRef ddx_ddy = lp_build_packed_ddx_ddy_twocoord(&bld->coord_bld, coords[0], coords[1]);
+-   LLVMValueRef float_size;
+-   LLVMTypeRef i32t = LLVMInt32TypeInContext(gallivm->context);
+-   LLVMValueRef index0 = LLVMConstInt(i32t, 0, 0);
+-   LLVMValueRef index1 = LLVMConstInt(i32t, 1, 0);
+-   const unsigned length = bld->coord_bld.type.length;
+-   const unsigned num_quads = length / 4;
+-   LLVMValueRef filter_table = bld->aniso_filter_table;
++   struct lp_build_context *int_coord_bld = &bld->int_coord_bld;
+    LLVMValueRef size0, row_stride0_vec, img_stride0_vec;
+    LLVMValueRef data_ptr0, mipoff0 = NULL;
+ 
+@@ -2223,9 +2215,8 @@ lp_build_sample_aniso(struct lp_build_sample_context *bld,
+       mipoff0 = lp_build_get_mip_offsets(bld, ilevel0);
+    }
+ 
+-   float_size = lp_build_int_to_float(&bld->float_size_in_bld, bld->int_size);
+-
+    LLVMValueRef float_size_lvl = lp_build_int_to_float(&bld->float_size_bld, size0);
++
+    /* extract width and height into vectors for use later */
+    static const unsigned char swizzle15[] = { /* no-op swizzle */
+       1, 1, 1, 1, 5, 5, 5, 5
+@@ -2242,397 +2233,95 @@ lp_build_sample_aniso(struct lp_build_sample_context *bld,
+                                        bld->float_size_bld.type.length,
+                                        bld->coord_bld.type.length);
+ 
+-
+-   /* shuffle width/height for ddx/ddy calculations. */
+-   LLVMValueRef shuffles[LP_MAX_VECTOR_LENGTH / 4];
+-
+-   for (unsigned i = 0; i < num_quads; i++) {
+-      shuffles[i*4+0] = shuffles[i*4+1] = index0;
+-      shuffles[i*4+2] = shuffles[i*4+3] = index1;
+-   }
+-
+-   LLVMValueRef floatdim =
+-      LLVMBuildShuffleVector(builder, float_size, float_size,
+-                             LLVMConstVector(shuffles, length), "");
+-
+-   ddx_ddy = lp_build_mul(coord_bld, ddx_ddy, floatdim);
+-
+-   LLVMValueRef scaling =
+-      lp_build_shl(&bld->leveli_bld, bld->leveli_bld.one, ilevel0);
+-   scaling = lp_build_int_to_float(&bld->levelf_bld, scaling);
+-   scaling = lp_build_rcp(&bld->levelf_bld, scaling);
+-
+-   if (bld->levelf_bld.type.length != length) {
+-      if (bld->levelf_bld.type.length == 1) {
+-         scaling = lp_build_broadcast_scalar(coord_bld,
+-                                             scaling);
+-      } else {
+-         scaling = lp_build_unpack_broadcast_aos_scalars(bld->gallivm,
+-                                                         bld->levelf_bld.type,
+-                                                         coord_bld->type,
+-                                                         scaling);
+-      }
++   /* Gradient of the u coordinate in screen space. */
++   LLVMValueRef dudx = lp_build_ddx(coord_bld, coords[0]);
++   LLVMValueRef dudy = lp_build_ddy(coord_bld, coords[0]);
++
++   /* Gradient of the v coordinate in screen space. */
++   LLVMValueRef dvdx = lp_build_ddx(coord_bld, coords[1]);
++   LLVMValueRef dvdy = lp_build_ddy(coord_bld, coords[1]);
++
++   LLVMValueRef rho_x = lp_build_mul(coord_bld, lp_build_max(coord_bld, lp_build_abs(coord_bld, dudx), lp_build_abs(coord_bld, dvdx)), width_dim);
++   LLVMValueRef rho_y = lp_build_mul(coord_bld, lp_build_max(coord_bld, lp_build_abs(coord_bld, dudy), lp_build_abs(coord_bld, dvdy)), height_dim);
++
++   /* Number of samples used for averaging. */
++   LLVMValueRef N = lp_build_iceil(coord_bld, lp_build_max(coord_bld, rho_x, rho_y));
++   N = lp_build_min(int_coord_bld, N, lp_build_const_int_vec(gallivm, int_coord_bld->type, 16));
++   LLVMValueRef wave_max_N = NULL;
++   for (uint32_t i = 0; i < coord_bld->type.length; i++) {
++      LLVMValueRef invocation_N = LLVMBuildExtractElement(builder, N, lp_build_const_int32(gallivm, i), "");
++      if (wave_max_N)
++         wave_max_N = lp_build_max(&bld->int_bld, wave_max_N, invocation_N);
++      else
++         wave_max_N = invocation_N;
+    }
+ 
+-   ddx_ddy = lp_build_mul(coord_bld, ddx_ddy, scaling);
++   LLVMValueRef sample_along_x_axis = lp_build_cmp(coord_bld, PIPE_FUNC_GREATER, rho_x, rho_y);
++   LLVMValueRef dudk = lp_build_select(coord_bld, sample_along_x_axis, dudx, dudy);
++   LLVMValueRef dvdk = lp_build_select(coord_bld, sample_along_x_axis, dvdx, dvdy);
+ 
+-   static const unsigned char swizzle01[] = { /* no-op swizzle */
+-      0, 1, 0, 1,
++   LLVMValueRef accumulator[4] = {
++      lp_build_alloca(gallivm, bld->texel_bld.vec_type, "r"),
++      lp_build_alloca(gallivm, bld->texel_bld.vec_type, "g"),
++      lp_build_alloca(gallivm, bld->texel_bld.vec_type, "b"),
++      lp_build_alloca(gallivm, bld->texel_bld.vec_type, "a"),
+    };
+-   static const unsigned char swizzle23[] = {
+-      2, 3, 2, 3,
+-   };
+-
+-   LLVMValueRef ddx_ddys, ddx_ddyt;
+-   ddx_ddys = lp_build_swizzle_aos(coord_bld, ddx_ddy, swizzle01);
+-   ddx_ddyt = lp_build_swizzle_aos(coord_bld, ddx_ddy, swizzle23);
+-
+-   /* compute ellipse coefficients */
+-   /* * A*x*x + B*x*y + C*y*y = F.*/
+-   /* float A = vx*vx+vy*vy+1; */
+-   LLVMValueRef A = lp_build_mul(coord_bld, ddx_ddyt, ddx_ddyt);
+-
+-   LLVMValueRef Ay = lp_build_swizzle_aos(coord_bld, A, swizzle15);
+-   A = lp_build_add(coord_bld, A, Ay);
+-   A = lp_build_add(coord_bld, A, coord_bld->one);
+-   A = lp_build_swizzle_aos(coord_bld, A, swizzle04);
+-
+-   /* float B = -2*(ux*vx+uy*vy); */
+-   LLVMValueRef B = lp_build_mul(coord_bld, ddx_ddys, ddx_ddyt);
+-   LLVMValueRef By = lp_build_swizzle_aos(coord_bld, B, swizzle15);
+-   B = lp_build_add(coord_bld, B, By);
+-   B = lp_build_mul_imm(coord_bld, B, -2);
+-   B = lp_build_swizzle_aos(coord_bld, B, swizzle04);
+-
+-   /* float C = ux*ux+uy*uy+1; */
+-   LLVMValueRef C = lp_build_mul(coord_bld, ddx_ddys, ddx_ddys);
+-   LLVMValueRef Cy = lp_build_swizzle_aos(coord_bld, C, swizzle15);
+-   C = lp_build_add(coord_bld, C, Cy);
+-   C = lp_build_add(coord_bld, C, coord_bld->one);
+-   C = lp_build_swizzle_aos(coord_bld, C, swizzle04);
+-
+-   /* float F = A*C-B*B/4.0f; */
+-   LLVMValueRef F = lp_build_mul(coord_bld, B, B);
+-   F = lp_build_div(coord_bld, F, lp_build_const_vec(gallivm, coord_bld->type, 4.0));
+-   LLVMValueRef F_p2 = lp_build_mul(coord_bld, A, C);
+-   F = lp_build_sub(coord_bld, F_p2, F);
+-
+-   /* compute ellipse bounding box in texture space */
+-   /* const float d = -B*B+4.0f*C*A; */
+-   LLVMValueRef d = lp_build_sub(coord_bld, coord_bld->zero, lp_build_mul(coord_bld, B, B));
+-   LLVMValueRef d_p2 = lp_build_mul(coord_bld, A, C);
+-   d_p2 = lp_build_mul_imm(coord_bld, d_p2, 4);
+-   d = lp_build_add(coord_bld, d, d_p2);
+-
+-   /* const float box_u = 2.0f / d * sqrtf(d*C*F); */
+-   /* box_u -> half of bbox with   */
+-   LLVMValueRef temp;
+-   temp = lp_build_mul(coord_bld, d, C);
+-   temp = lp_build_mul(coord_bld, temp, F);
+-   temp = lp_build_sqrt(coord_bld, temp);
+-
+-   LLVMValueRef box_u = lp_build_div(coord_bld, lp_build_const_vec(gallivm, coord_bld->type, 2.0), d);
+-   box_u = lp_build_mul(coord_bld, box_u, temp);
+-
+-   /* const float box_v = 2.0f / d * sqrtf(A*d*F); */
+-   /* box_v -> half of bbox height */
+-   temp = lp_build_mul(coord_bld, A, d);
+-   temp = lp_build_mul(coord_bld, temp, F);
+-   temp = lp_build_sqrt(coord_bld, temp);
+-
+-   LLVMValueRef box_v = lp_build_div(coord_bld, lp_build_const_vec(gallivm, coord_bld->type, 2.0), d);
+-   box_v = lp_build_mul(coord_bld, box_v, temp);
+-
+-   /* Scale ellipse formula to directly index the Filter Lookup Table.
+-    * i.e. scale so that F = WEIGHT_LUT_SIZE-1
+-    */
+-   LLVMValueRef formScale = lp_build_div(coord_bld, lp_build_const_vec(gallivm, coord_bld->type, WEIGHT_LUT_SIZE - 1), F);
+-
+-   A = lp_build_mul(coord_bld, A, formScale);
+-   B = lp_build_mul(coord_bld, B, formScale);
+-   C = lp_build_mul(coord_bld, C, formScale);
+-   /* F *= formScale; */ /* no need to scale F as we don't use it below here */
+-
+-   LLVMValueRef ddq = lp_build_mul_imm(coord_bld, A, 2);
+-
+-   /* Heckbert MS thesis, p. 59; scan over the bounding box of the ellipse
+-    * and incrementally update the value of Ax^2+Bxy*Cy^2; when this
+-    * value, q, is less than F, we're inside the ellipse
+-    */
+ 
+-   LLVMValueRef float_size0 = lp_build_int_to_float(float_size_bld, bld->int_size);
+-   LLVMValueRef width0 = lp_build_extract_broadcast(gallivm,
+-                                                    float_size_bld->type,
+-                                                    coord_bld->type,
+-                                                    float_size0, index0);
+-   LLVMValueRef height0 = lp_build_extract_broadcast(gallivm,
+-                                                     float_size_bld->type,
+-                                                     coord_bld->type,
+-                                                     float_size0, index1);
++   LLVMValueRef float_N = lp_build_int_to_float(coord_bld, N);
++   LLVMValueRef rcp_N = lp_build_rcp(coord_bld, float_N);
+ 
+-   /* texture->width0 * scaling */
+-   width0 = lp_build_mul(coord_bld, width0, scaling);
+-   /* texture->height0 * scaling */
+-   height0 = lp_build_mul(coord_bld, height0, scaling);
+-
+-   /* tex_u = -0.5f * s[j] * texture->width0 * scaling */
+-   LLVMValueRef tex_u = lp_build_mul(coord_bld, coords[0], width0);
+-   tex_u = lp_build_add(coord_bld, tex_u, lp_build_const_vec(gallivm, coord_bld->type, -0.5f));
+-
+-   /* tex_v = -0.5f * t[j] * texture->height0 * scaling */
+-   LLVMValueRef tex_v = lp_build_mul(coord_bld, coords[1], height0);
+-   tex_v = lp_build_add(coord_bld, tex_v, lp_build_const_vec(gallivm, coord_bld->type, -0.5f));
+-
+-   /* const int u0 = (int) floorf(tex_u - box_u); */
+-   LLVMValueRef u0 = lp_build_itrunc(coord_bld, lp_build_floor(coord_bld, lp_build_sub(coord_bld, tex_u, box_u)));
+-   /* const int u1 = (int) ceilf(tex_u + box_u); */
+-   LLVMValueRef u1 = lp_build_itrunc(coord_bld, lp_build_ceil(coord_bld, lp_build_add(coord_bld, tex_u, box_u)));
+-
+-   /* const int v0 = (int) floorf(tex_v - box_v); */
+-   LLVMValueRef v0 = lp_build_itrunc(coord_bld, lp_build_floor(coord_bld, lp_build_sub(coord_bld, tex_v, box_v)));
+-   /* const int v1 = (int) ceilf(tex_v + box_v); */
+-   LLVMValueRef v1 = lp_build_itrunc(coord_bld, lp_build_ceil(coord_bld, lp_build_add(coord_bld, tex_v, box_v)));
+-
+-   /* const float U = u0 - tex_u; */
+-   LLVMValueRef U = lp_build_sub(coord_bld, lp_build_int_to_float(coord_bld, u0), tex_u);
+-
+-   /* A * (2 * U + 1) */
+-   LLVMValueRef dq_base = lp_build_mul_imm(coord_bld, U, 2);
+-   dq_base = lp_build_add(coord_bld, dq_base, coord_bld->one);
+-   dq_base = lp_build_mul(coord_bld, dq_base, A);
+-
+-   /* A * U * U */
+-   LLVMValueRef q_base = lp_build_mul(coord_bld, U, U);
+-   q_base = lp_build_mul(coord_bld, q_base, A);
+-
+-   LLVMValueRef colors0[4];
+-   LLVMValueRef den_store = lp_build_alloca(gallivm, bld->texel_bld.vec_type, "den");
+-
+-   for (unsigned chan = 0; chan < 4; chan++)
+-      colors0[chan] = lp_build_alloca(gallivm, bld->texel_bld.vec_type, "colors");
+-
+-   LLVMValueRef q_store, dq_store;
+-   q_store = lp_build_alloca(gallivm, bld->coord_bld.vec_type, "q");
+-   dq_store = lp_build_alloca(gallivm, bld->coord_bld.vec_type, "dq");
+-
+-   LLVMValueRef v_limiter = lp_build_alloca(gallivm, bld->int_coord_bld.vec_type, "v_limiter");
+-   LLVMValueRef u_limiter = lp_build_alloca(gallivm, bld->int_coord_bld.vec_type, "u_limiter");
+-
+-   LLVMBuildStore(builder, v0, v_limiter);
+-
+-   /* create an LLVM loop block for the V iterator */
+-   LLVMBasicBlockRef v_loop_block = lp_build_insert_new_block(gallivm, "vloop");
+-
+-   LLVMBuildBr(builder, v_loop_block);
+-   LLVMPositionBuilderAtEnd(builder, v_loop_block);
+-
+-   LLVMValueRef v_val = LLVMBuildLoad2(builder, bld->int_coord_bld.vec_type, v_limiter, "");
+-   LLVMValueRef v_mask = LLVMBuildICmp(builder, LLVMIntSLE, v_val, v1, "");
+-
+-   /* loop over V values. */
++   struct lp_build_for_loop_state loop_state;
++   lp_build_for_loop_begin(&loop_state, gallivm, lp_build_const_int32(gallivm, 0),
++                           LLVMIntULT, wave_max_N, lp_build_const_int32(gallivm, 1));
+    {
+-      /*  const float V = v - tex_v; */
+-      LLVMValueRef V =
+-         lp_build_sub(coord_bld,
+-                      lp_build_int_to_float(coord_bld, v_val), tex_v);
+-
+-      /* float dq = dq_base + B * V; */
+-      LLVMValueRef dq = lp_build_mul(coord_bld, V, B);
+-      dq = lp_build_add(coord_bld, dq, dq_base);
+-
+-      /* float q = (C * V + B * U) * V + q_base */
+-      LLVMValueRef q = lp_build_mul(coord_bld, C, V);
+-      q = lp_build_add(coord_bld, q, lp_build_mul(coord_bld, B, U));
+-      q = lp_build_mul(coord_bld, q, V);
+-      q = lp_build_add(coord_bld, q, q_base);
+-
+-      LLVMBuildStore(builder, q, q_store);
+-      LLVMBuildStore(builder, dq, dq_store);
+-
+-      LLVMBuildStore(builder, u0, u_limiter);
++      LLVMValueRef k = loop_state.counter;
++      k = lp_build_broadcast_scalar(int_coord_bld, k);
+ 
+-      /* create an LLVM loop block for the V iterator */
+-      LLVMBasicBlockRef u_loop_block = lp_build_insert_new_block(gallivm, "uloop");
++      LLVMValueRef float_k = lp_build_int_to_float(coord_bld, k);
++      float_k = lp_build_mul(coord_bld, float_k, rcp_N);
++      float_k = lp_build_add(coord_bld, float_k, lp_build_const_vec(gallivm, coord_bld->type, -0.5));
+ 
+-      LLVMBuildBr(builder, u_loop_block);
+-      LLVMPositionBuilderAtEnd(builder, u_loop_block);
++      LLVMValueRef u_offset = lp_build_mul(coord_bld, float_k, dudk);
++      LLVMValueRef v_offset = lp_build_mul(coord_bld, float_k, dvdk);
+ 
+-      LLVMValueRef u_val = LLVMBuildLoad2(builder, bld->int_coord_bld.vec_type,
+-                                          u_limiter, "");
+-      LLVMValueRef u_mask = LLVMBuildICmp(builder,
+-                                          LLVMIntSLE,
+-                                          u_val,
+-                                          u1, "");
+-
+-      /* loop over U values */
+-      {
+-         /* q = (int)q */
+-         q = lp_build_itrunc(coord_bld,
+-                             LLVMBuildLoad2(builder, bld->coord_bld.vec_type,
+-                                            q_store, ""));
+-
+-         /*
+-          * avoid OOB access to filter table, generate a mask for q > 1024,
+-          * then truncate it.
+-          */
+-         LLVMValueRef q_mask = LLVMBuildICmp(builder,
+-                                             LLVMIntSLE,
+-                                             q,
+-                                             lp_build_const_int_vec(gallivm, bld->int_coord_bld.type, 0x3ff), "");
+-         q_mask = LLVMBuildSExt(builder, q_mask, bld->int_coord_bld.vec_type, "");
+-
+-         q = lp_build_max(&bld->int_coord_bld, q, bld->int_coord_bld.zero);
+-         q = lp_build_and(&bld->int_coord_bld, q, lp_build_const_int_vec(gallivm, bld->int_coord_bld.type, 0x3ff));
+-
+-         /* update the offsets to deal with float size. */
+-         q = lp_build_mul_imm(&bld->int_coord_bld, q, 4);
+-         filter_table = LLVMBuildBitCast(gallivm->builder, filter_table, LLVMPointerType(LLVMInt8TypeInContext(gallivm->context), 0), "");
+-
+-         /* Lookup weights in filter table */
+-         LLVMValueRef weights = lp_build_gather(gallivm, coord_bld->type.length,
+-                                                coord_bld->type.width,
+-                                                lp_elem_type(coord_bld->type),
+-                                                true, filter_table, q, true);
++      LLVMValueRef sample_coords[4] = {
++         lp_build_add(coord_bld, coords[0], u_offset),
++         lp_build_add(coord_bld, coords[1], v_offset),
++         coords[2],
++         coords[3],
++      };
+ 
+-         /*
+-          * Mask off the weights here which should ensure no-op for loops
+-          * where some of the u/v values are not being calculated.
++      if (bld->static_texture_state->target == PIPE_TEXTURE_CUBE ||
++          bld->static_texture_state->target == PIPE_TEXTURE_CUBE_ARRAY) {
++         /* Make sure the coordinates stay in bounds for PIPE_TEXTURE_CUBE loads since
++          * lp_build_sample_image_linear uses less clamping for them.
+           */
+-         weights = LLVMBuildBitCast(builder, weights, bld->int_coord_bld.vec_type, "");
+-         weights = lp_build_and(&bld->int_coord_bld, weights, LLVMBuildSExt(builder, u_mask, bld->int_coord_bld.vec_type, ""));
+-         weights = lp_build_and(&bld->int_coord_bld, weights, LLVMBuildSExt(builder, v_mask, bld->int_coord_bld.vec_type, ""));
+-         weights = lp_build_and(&bld->int_coord_bld, weights, q_mask);
+-         weights = LLVMBuildBitCast(builder, weights, bld->coord_bld.vec_type, "");
+-
+-         /* if the weights are all 0 avoid doing the sampling at all. */
+-         struct lp_build_if_state noloadw0;
+-
+-         LLVMValueRef wnz = LLVMBuildFCmp(gallivm->builder, LLVMRealUNE,
+-                                          weights, bld->coord_bld.zero, "");
+-         wnz = LLVMBuildSExt(builder, wnz, bld->int_coord_bld.vec_type, "");
+-         wnz = lp_build_any_true_range(&bld->coord_bld, bld->coord_bld.type.length, wnz);
+-         lp_build_if(&noloadw0, gallivm, wnz);
+-         LLVMValueRef new_coords[4] = {
+-            lp_build_div(coord_bld,
+-                         lp_build_add(coord_bld, lp_build_int_to_float(coord_bld, u_val),
+-                                      lp_build_const_vec(gallivm, coord_bld->type, 0.5)), width_dim),
+-            lp_build_div(coord_bld,
+-                         lp_build_add(coord_bld, lp_build_int_to_float(coord_bld, v_val),
+-                                      lp_build_const_vec(gallivm, coord_bld->type, 0.5)), height_dim),
+-            coords[2],
+-            coords[3],
+-         };
+-
+-         /* multiple colors by weight and add in. */
+-         LLVMValueRef temp_colors[4];
+-         lp_build_sample_image_nearest(bld, size0,
+-                                       row_stride0_vec, img_stride0_vec,
+-                                       data_ptr0, mipoff0, ilevel0, new_coords, offsets,
+-                                       temp_colors);
+-
+-         for (unsigned chan = 0; chan < 4; chan++) {
+-            LLVMValueRef tcolor = LLVMBuildLoad2(builder, bld->texel_bld.vec_type, colors0[chan], "");
+-
+-            tcolor = lp_build_add(&bld->texel_bld, tcolor, lp_build_mul(&bld->texel_bld, temp_colors[chan], weights));
+-            LLVMBuildStore(builder, tcolor, colors0[chan]);
+-         }
+-
+-         /* den += weight; */
+-         LLVMValueRef den = LLVMBuildLoad2(builder, bld->texel_bld.vec_type, den_store, "");
+-         den = lp_build_add(&bld->texel_bld, den, weights);
+-         LLVMBuildStore(builder, den, den_store);
+-         lp_build_endif(&noloadw0);
+-
+-         /* lookup q in filter table */
+-         q = LLVMBuildLoad2(builder, bld->texel_bld.vec_type, q_store, "");
+-         dq = LLVMBuildLoad2(builder, bld->texel_bld.vec_type, dq_store, "");
+-         /* q += dq; */
+-         /* dq += ddq; */
+-         q = lp_build_add(coord_bld, q, dq);
+-         dq = lp_build_add(coord_bld, dq, ddq);
+-         LLVMBuildStore(builder, q, q_store);
+-         LLVMBuildStore(builder, dq, dq_store);
++         sample_coords[0] = lp_build_max(coord_bld, sample_coords[0], bld->coord_bld.zero);
++         sample_coords[0] = lp_build_min(coord_bld, sample_coords[0], bld->coord_bld.one);
++         sample_coords[1] = lp_build_max(coord_bld, sample_coords[1], bld->coord_bld.zero);
++         sample_coords[1] = lp_build_min(coord_bld, sample_coords[1], bld->coord_bld.one);
+       }
+-      /* u += 1 */
+-      u_val = LLVMBuildLoad2(builder, bld->int_coord_bld.vec_type, u_limiter, "");
+-      u_val = lp_build_add(&bld->int_coord_bld, u_val, bld->int_coord_bld.one);
+-      LLVMBuildStore(builder, u_val, u_limiter);
+-
+-      u_mask = LLVMBuildICmp(builder,
+-                             LLVMIntSLE,
+-                             u_val,
+-                             u1, "");
+-      LLVMValueRef u_end_cond = LLVMBuildSExt(builder, u_mask, bld->int_coord_bld.vec_type, "");
+-      u_end_cond = lp_build_any_true_range(&bld->coord_bld, bld->coord_bld.type.length, u_end_cond);
+-
+-      LLVMBasicBlockRef u_end_loop = lp_build_insert_new_block(gallivm, "u_end_loop");
+-
+-      LLVMBuildCondBr(builder, u_end_cond,
+-                      u_loop_block, u_end_loop);
+-
+-      LLVMPositionBuilderAtEnd(builder, u_end_loop);
+-
+-   }
+ 
+-   /* v += 1 */
+-   v_val = LLVMBuildLoad2(builder, bld->int_coord_bld.vec_type, v_limiter, "");
+-   v_val = lp_build_add(&bld->int_coord_bld, v_val, bld->int_coord_bld.one);
+-   LLVMBuildStore(builder, v_val, v_limiter);
+-
+-   v_mask = LLVMBuildICmp(builder,
+-                          LLVMIntSLE,
+-                          v_val,
+-                          v1, "");
+-   LLVMValueRef v_end_cond = LLVMBuildSExt(builder, v_mask,
+-                                           bld->int_coord_bld.vec_type, "");
+-   v_end_cond = lp_build_any_true_range(&bld->coord_bld,
+-                                        bld->coord_bld.type.length, v_end_cond);
+-
+-   LLVMBasicBlockRef v_end_loop = lp_build_insert_new_block(gallivm, "v_end_loop");
+-
+-   LLVMBuildCondBr(builder, v_end_cond,
+-                   v_loop_block, v_end_loop);
+-
+-   LLVMPositionBuilderAtEnd(builder, v_end_loop);
+-
+-   LLVMValueRef den = LLVMBuildLoad2(builder, bld->texel_bld.vec_type, den_store, "");
+-
+-   for (unsigned chan = 0; chan < 4; chan++) {
+-      colors0[chan] =
+-         lp_build_div(&bld->texel_bld,
+-                      LLVMBuildLoad2(builder, bld->texel_bld.vec_type,
+-                                     colors0[chan], ""), den);
+-   }
+-
+-   LLVMValueRef den0 = lp_build_cmp(&bld->coord_bld, PIPE_FUNC_EQUAL,
+-                                    den, bld->coord_bld.zero);
+-
+-   LLVMValueRef den0_any =
+-      lp_build_any_true_range(&bld->coord_bld,
+-                              bld->coord_bld.type.length, den0);
+-
+-   struct lp_build_if_state den0_fallback;
+-   lp_build_if(&den0_fallback, gallivm, den0_any);
+-   {
+-      LLVMValueRef colors_den0[4];
++      LLVMValueRef sample_color[4];
+       lp_build_sample_image_linear(bld, false, size0, NULL,
+                                    row_stride0_vec, img_stride0_vec,
+-                                   data_ptr0, mipoff0, ilevel0, coords, offsets,
+-                                   colors_den0);
+-      for (unsigned chan = 0; chan < 4; chan++) {
+-         LLVMValueRef chan_val =
+-            lp_build_select(&bld->texel_bld, den0,
+-                            colors_den0[chan], colors0[chan]);
+-         LLVMBuildStore(builder, chan_val, colors_out[chan]);
++                                   data_ptr0, mipoff0, ilevel0, sample_coords, offsets,
++                                   sample_color);
++
++      LLVMValueRef oob = lp_build_cmp(int_coord_bld, PIPE_FUNC_GEQUAL, k, N);
++
++      for (uint32_t c = 0; c < 4; c++) {
++         LLVMValueRef tmp = LLVMBuildLoad2(builder, bld->texel_bld.vec_type, accumulator[c], "");
++         tmp = lp_build_select(&bld->texel_bld, oob, tmp, LLVMBuildFAdd(builder, tmp, sample_color[c], ""));
++         LLVMBuildStore(builder, tmp, accumulator[c]);
+       }
+    }
+-   lp_build_else(&den0_fallback);
+-   {
+-      for (unsigned chan = 0; chan < 4; chan++) {
+-         LLVMBuildStore(builder, colors0[chan], colors_out[chan]);
+-      }
++   lp_build_for_loop_end(&loop_state);
++
++   for (uint32_t c = 0; c < 4; c++) {
++      LLVMValueRef sum = LLVMBuildLoad2(builder, bld->texel_bld.vec_type, accumulator[c], "");
++      LLVMBuildStore(builder, lp_build_mul(&bld->texel_bld, sum, rcp_N), colors_out[c]);
+    }
+-   lp_build_endif(&den0_fallback);
+ }
+ 
+ 
+-- 
+2.34.1
+

--- a/meta-flex-staging/recipes-graphics/mesa/files/0003-llvmpipe-Remove-unused-AF-code.patch
+++ b/meta-flex-staging/recipes-graphics/mesa/files/0003-llvmpipe-Remove-unused-AF-code.patch
@@ -1,0 +1,632 @@
+From c092ccd30bf0c0366f04b63aa60ea9f2d423b416 Mon Sep 17 00:00:00 2001
+From: Konstantin Seurer <konstantin.seurer@gmail.com>
+Date: Sat, 19 Oct 2024 15:21:09 +0200
+Subject: [PATCH 3/9] llvmpipe: Remove unused AF code
+
+The table and some other parameters are not used.
+
+Reviewed-by: Aleksi Sapon <aleksi.sapon@autodesk.com>
+Reviewed-by: Adam Jackson <ajax@redhat.com>
+Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/31748>
+
+Upstream-Status: Backport [https://gitlab.freedesktop.org/mesa/mesa/-/commit/0797a14c52c1537f62ccf179148ced6bd00c7b6a]
+---
+ src/gallium/auxiliary/draw/draw_llvm.c        |  11 --
+ .../draw/draw_pt_fetch_shade_pipeline_llvm.c  |   2 -
+ .../auxiliary/gallivm/lp_bld_jit_sample.c     |   2 -
+ .../auxiliary/gallivm/lp_bld_jit_types.c      |   6 -
+ .../auxiliary/gallivm/lp_bld_jit_types.h      |   5 -
+ src/gallium/auxiliary/gallivm/lp_bld_nir.c    |   1 -
+ src/gallium/auxiliary/gallivm/lp_bld_nir.h    |   2 -
+ .../auxiliary/gallivm/lp_bld_nir_soa.c        |   1 -
+ src/gallium/auxiliary/gallivm/lp_bld_sample.c | 146 ------------------
+ src/gallium/auxiliary/gallivm/lp_bld_sample.h |   5 -
+ .../auxiliary/gallivm/lp_bld_sample_soa.c     |  24 +--
+ src/gallium/auxiliary/gallivm/lp_bld_tgsi.h   |   1 -
+ src/gallium/drivers/llvmpipe/lp_jit.h         |   3 -
+ src/gallium/drivers/llvmpipe/lp_setup.c       |   2 -
+ src/gallium/drivers/llvmpipe/lp_state_cs.c    |  13 --
+ src/gallium/drivers/llvmpipe/lp_state_fs.c    |   1 -
+ .../drivers/llvmpipe/lp_texture_handle.c      |   4 +-
+ 17 files changed, 4 insertions(+), 225 deletions(-)
+
+diff --git a/src/gallium/auxiliary/draw/draw_llvm.c b/src/gallium/auxiliary/draw/draw_llvm.c
+index 886d36f7d2a..40ed7cd0bc4 100644
+--- a/src/gallium/auxiliary/draw/draw_llvm.c
++++ b/src/gallium/auxiliary/draw/draw_llvm.c
+@@ -610,9 +610,6 @@ generate_vs(struct draw_llvm_variant *variant,
+    params.info = &llvm->draw->vs.vertex_shader->info;
+    params.ssbo_ptr = ssbos_ptr;
+    params.image = draw_image;
+-   params.aniso_filter_table = lp_jit_resources_aniso_filter_table(variant->gallivm,
+-                                                                   variant->resources_type,
+-                                                                   resources_ptr);
+ 
+    if (llvm->draw->vs.vertex_shader->state.ir.nir &&
+        llvm->draw->vs.vertex_shader->state.type == PIPE_SHADER_IR_NIR) {
+@@ -2464,10 +2461,6 @@ draw_gs_llvm_generate(struct draw_llvm *llvm,
+    params.ssbo_ptr = ssbos_ptr;
+    params.image = image;
+    params.gs_vertex_streams = variant->shader->base.num_vertex_streams;
+-   params.aniso_filter_table = lp_jit_resources_aniso_filter_table(gallivm,
+-                                                                   variant->resources_type,
+-                                                                   resources_ptr);
+-
+ 
+    if (llvm->draw->gs.geometry_shader->state.type == PIPE_SHADER_IR_TGSI)
+       lp_build_tgsi_soa(variant->gallivm,
+@@ -3125,9 +3118,6 @@ draw_tcs_llvm_generate(struct draw_llvm *llvm,
+       params.image = image;
+       params.coro = &coro_info;
+       params.tcs_iface = &tcs_iface.base;
+-      params.aniso_filter_table = lp_jit_resources_aniso_filter_table(gallivm,
+-                                                                      variant->resources_type,
+-                                                                      resources_ptr);
+ 
+       lp_build_nir_soa(variant->gallivm,
+                        llvm->draw->tcs.tess_ctrl_shader->state.ir.nir,
+@@ -3652,7 +3642,6 @@ draw_tes_llvm_generate(struct draw_llvm *llvm,
+       params.ssbo_ptr = ssbos_ptr;
+       params.image = image;
+       params.tes_iface = &tes_iface.base;
+-      params.aniso_filter_table = lp_jit_resources_aniso_filter_table(gallivm, variant->resources_type, resources_ptr);
+ 
+       lp_build_nir_soa(variant->gallivm,
+                        llvm->draw->tes.tess_eval_shader->state.ir.nir,
+diff --git a/src/gallium/auxiliary/draw/draw_pt_fetch_shade_pipeline_llvm.c b/src/gallium/auxiliary/draw/draw_pt_fetch_shade_pipeline_llvm.c
+index 940fec5cf62..2bc7abec0b6 100644
+--- a/src/gallium/auxiliary/draw/draw_pt_fetch_shade_pipeline_llvm.c
++++ b/src/gallium/auxiliary/draw/draw_pt_fetch_shade_pipeline_llvm.c
+@@ -453,8 +453,6 @@ llvm_middle_end_bind_parameters(struct draw_pt_middle_end *middle)
+             llvm->jit_resources[shader_type].ssbos[i].u = (const uint32_t *)fake_const_buf;
+          }
+       }
+-
+-      llvm->jit_resources[shader_type].aniso_filter_table = lp_build_sample_aniso_filter_table();
+    }
+ 
+    llvm->vs_jit_context.planes =
+diff --git a/src/gallium/auxiliary/gallivm/lp_bld_jit_sample.c b/src/gallium/auxiliary/gallivm/lp_bld_jit_sample.c
+index af8b7d37e9e..09e58652a91 100644
+--- a/src/gallium/auxiliary/gallivm/lp_bld_jit_sample.c
++++ b/src/gallium/auxiliary/gallivm/lp_bld_jit_sample.c
+@@ -225,8 +225,6 @@ lp_bld_llvm_sampler_soa_emit_fetch_texel(const struct lp_build_sampler_soa *base
+       args[num_args++] = texture_descriptor;
+       args[num_args++] = sampler_desc_ptr;
+ 
+-      args[num_args++] = params->aniso_filter_table;
+-
+       LLVMTypeRef coord_type;
+       if (op_type == LP_SAMPLER_OP_FETCH)
+          coord_type = lp_build_int_vec_type(gallivm, params->type);
+diff --git a/src/gallium/auxiliary/gallivm/lp_bld_jit_types.c b/src/gallium/auxiliary/gallivm/lp_bld_jit_types.c
+index 5b1401ca3d2..22d5266d219 100644
+--- a/src/gallium/auxiliary/gallivm/lp_bld_jit_types.c
++++ b/src/gallium/auxiliary/gallivm/lp_bld_jit_types.c
+@@ -296,7 +296,6 @@ lp_build_jit_resources_type(struct gallivm_state *gallivm)
+                                                    PIPE_MAX_SAMPLERS);
+    elem_types[LP_JIT_RES_IMAGES] = LLVMArrayType(image_type,
+                                                  PIPE_MAX_SHADER_IMAGES);
+-   elem_types[LP_JIT_RES_ANISO_FILTER_TABLE] = LLVMPointerType(LLVMFloatTypeInContext(gallivm->context), 0);
+ 
+    resources_type = LLVMStructTypeInContext(gallivm->context, elem_types,
+                                             ARRAY_SIZE(elem_types), 0);
+@@ -316,9 +315,6 @@ lp_build_jit_resources_type(struct gallivm_state *gallivm)
+    LP_CHECK_MEMBER_OFFSET(struct lp_jit_resources, images,
+                           gallivm->target, resources_type,
+                           LP_JIT_RES_IMAGES);
+-   LP_CHECK_MEMBER_OFFSET(struct lp_jit_resources, aniso_filter_table,
+-                          gallivm->target, resources_type,
+-                          LP_JIT_RES_ANISO_FILTER_TABLE);
+ 
+    return resources_type;
+ }
+@@ -802,8 +798,6 @@ lp_build_sample_function_type(struct gallivm_state *gallivm, uint32_t sample_key
+    arg_types[num_params++] = LLVMInt64TypeInContext(gallivm->context);
+    arg_types[num_params++] = LLVMInt64TypeInContext(gallivm->context);
+ 
+-   arg_types[num_params++] = LLVMPointerType(LLVMFloatTypeInContext(gallivm->context), 0);
+-
+    for (unsigned i = 0; i < 4; i++)
+       arg_types[num_params++] = coord_type;
+ 
+diff --git a/src/gallium/auxiliary/gallivm/lp_bld_jit_types.h b/src/gallium/auxiliary/gallivm/lp_bld_jit_types.h
+index c23a69c7ed5..b8d3c897dfa 100644
+--- a/src/gallium/auxiliary/gallivm/lp_bld_jit_types.h
++++ b/src/gallium/auxiliary/gallivm/lp_bld_jit_types.h
+@@ -147,7 +147,6 @@ struct lp_jit_resources {
+    struct lp_jit_texture textures[PIPE_MAX_SHADER_SAMPLER_VIEWS];
+    struct lp_jit_sampler samplers[PIPE_MAX_SAMPLERS];
+    struct lp_jit_image images[PIPE_MAX_SHADER_IMAGES];
+-   const float *aniso_filter_table;
+ };
+ 
+ enum {
+@@ -156,7 +155,6 @@ enum {
+    LP_JIT_RES_TEXTURES,
+    LP_JIT_RES_SAMPLERS,
+    LP_JIT_RES_IMAGES,
+-   LP_JIT_RES_ANISO_FILTER_TABLE,
+    LP_JIT_RES_COUNT,
+ };
+ 
+@@ -175,9 +173,6 @@ enum {
+ #define lp_jit_resources_images(_gallivm, _type, _ptr)                   \
+    lp_build_struct_get_ptr2(_gallivm, _type, _ptr, LP_JIT_RES_IMAGES, "images")
+ 
+-#define lp_jit_resources_aniso_filter_table(_gallivm, _type, _ptr)       \
+-   lp_build_struct_get2(_gallivm, _type, _ptr, LP_JIT_RES_ANISO_FILTER_TABLE, "aniso_filter_table")
+-
+ LLVMTypeRef
+ lp_build_jit_resources_type(struct gallivm_state *gallivm);
+ 
+diff --git a/src/gallium/auxiliary/gallivm/lp_bld_nir.c b/src/gallium/auxiliary/gallivm/lp_bld_nir.c
+index d7150e91c20..6a78aac039a 100644
+--- a/src/gallium/auxiliary/gallivm/lp_bld_nir.c
++++ b/src/gallium/auxiliary/gallivm/lp_bld_nir.c
+@@ -2662,7 +2662,6 @@ visit_tex(struct lp_build_nir_context *bld_base, nir_tex_instr *instr)
+    params.texel = texel;
+    params.lod = explicit_lod;
+    params.ms_index = ms_index;
+-   params.aniso_filter_table = bld_base->aniso_filter_table;
+    params.texture_resource = texture_resource;
+    params.sampler_resource = sampler_resource;
+    bld_base->tex(bld_base, &params);
+diff --git a/src/gallium/auxiliary/gallivm/lp_bld_nir.h b/src/gallium/auxiliary/gallivm/lp_bld_nir.h
+index 4a731ea5d95..e04e2c09ac1 100644
+--- a/src/gallium/auxiliary/gallivm/lp_bld_nir.h
++++ b/src/gallium/auxiliary/gallivm/lp_bld_nir.h
+@@ -89,8 +89,6 @@ struct lp_build_nir_context
+    /** Value range analysis hash table used in code generation. */
+    struct hash_table *range_ht;
+ 
+-   LLVMValueRef aniso_filter_table;
+-
+    LLVMValueRef func;
+    nir_shader *shader;
+ 
+diff --git a/src/gallium/auxiliary/gallivm/lp_bld_nir_soa.c b/src/gallium/auxiliary/gallivm/lp_bld_nir_soa.c
+index 56214bf907c..c0c39644e79 100644
+--- a/src/gallium/auxiliary/gallivm/lp_bld_nir_soa.c
++++ b/src/gallium/auxiliary/gallivm/lp_bld_nir_soa.c
+@@ -3145,7 +3145,6 @@ void lp_build_nir_soa_func(struct gallivm_state *gallivm,
+    bld.resources_ptr = params->resources_ptr;
+    bld.thread_data_type = params->thread_data_type;
+    bld.thread_data_ptr = params->thread_data_ptr;
+-   bld.bld_base.aniso_filter_table = params->aniso_filter_table;
+    bld.image = params->image;
+    bld.shared_ptr = params->shared_ptr;
+    bld.payload_ptr = params->payload_ptr;
+diff --git a/src/gallium/auxiliary/gallivm/lp_bld_sample.c b/src/gallium/auxiliary/gallivm/lp_bld_sample.c
+index a6061abd561..1f0e5818fe0 100644
+--- a/src/gallium/auxiliary/gallivm/lp_bld_sample.c
++++ b/src/gallium/auxiliary/gallivm/lp_bld_sample.c
+@@ -2541,149 +2541,3 @@ lp_build_reduce_filter_3d(struct lp_build_context *bld,
+       break;
+    }
+ }
+-
+-
+-/*
+- * generated from
+- * const float alpha = 2;
+- * for (unsigned i = 0; i < WEIGHT_LUT_SIZE; i++) {
+- *    const float r2 = (float) i / (float) (WEIGHT_LUT_SIZE - 1);
+- *    const float weight = (float)expf(-alpha * r2);
+- */
+-static const float aniso_filter_table[1024] = {
+-   1.000000, 0.998047, 0.996098, 0.994152, 0.992210, 0.990272, 0.988338, 0.986408,
+-   0.984481, 0.982559, 0.980640, 0.978724, 0.976813, 0.974905, 0.973001, 0.971100,
+-   0.969204, 0.967311, 0.965421, 0.963536, 0.961654, 0.959776, 0.957901, 0.956030,
+-   0.954163, 0.952299, 0.950439, 0.948583, 0.946730, 0.944881, 0.943036, 0.941194,
+-   0.939356, 0.937521, 0.935690, 0.933862, 0.932038, 0.930218, 0.928401, 0.926588,
+-   0.924778, 0.922972, 0.921169, 0.919370, 0.917575, 0.915782, 0.913994, 0.912209,
+-   0.910427, 0.908649, 0.906874, 0.905103, 0.903335, 0.901571, 0.899810, 0.898052,
+-   0.896298, 0.894548, 0.892801, 0.891057, 0.889317, 0.887580, 0.885846, 0.884116,
+-   0.882389, 0.880666, 0.878946, 0.877229, 0.875516, 0.873806, 0.872099, 0.870396,
+-   0.868696, 0.866999, 0.865306, 0.863616, 0.861929, 0.860245, 0.858565, 0.856888,
+-   0.855215, 0.853544, 0.851877, 0.850213, 0.848553, 0.846896, 0.845241, 0.843591,
+-   0.841943, 0.840299, 0.838657, 0.837019, 0.835385, 0.833753, 0.832124, 0.830499,
+-   0.828877, 0.827258, 0.825643, 0.824030, 0.822421, 0.820814, 0.819211, 0.817611,
+-   0.816014, 0.814420, 0.812830, 0.811242, 0.809658, 0.808076, 0.806498, 0.804923,
+-   0.803351, 0.801782, 0.800216, 0.798653, 0.797093, 0.795536, 0.793982, 0.792432,
+-   0.790884, 0.789339, 0.787798, 0.786259, 0.784723, 0.783191, 0.781661, 0.780134,
+-   0.778610, 0.777090, 0.775572, 0.774057, 0.772545, 0.771037, 0.769531, 0.768028,
+-   0.766528, 0.765030, 0.763536, 0.762045, 0.760557, 0.759071, 0.757589, 0.756109,
+-   0.754632, 0.753158, 0.751687, 0.750219, 0.748754, 0.747291, 0.745832, 0.744375,
+-   0.742921, 0.741470, 0.740022, 0.738577, 0.737134, 0.735694, 0.734258, 0.732823,
+-   0.731392, 0.729964, 0.728538, 0.727115, 0.725695, 0.724278, 0.722863, 0.721451,
+-   0.720042, 0.718636, 0.717232, 0.715831, 0.714433, 0.713038, 0.711645, 0.710255,
+-   0.708868, 0.707483, 0.706102, 0.704723, 0.703346, 0.701972, 0.700601, 0.699233,
+-   0.697867, 0.696504, 0.695144, 0.693786, 0.692431, 0.691079, 0.689729, 0.688382,
+-   0.687037, 0.685696, 0.684356, 0.683020, 0.681686, 0.680354, 0.679025, 0.677699,
+-   0.676376, 0.675054, 0.673736, 0.672420, 0.671107, 0.669796, 0.668488, 0.667182,
+-   0.665879, 0.664579, 0.663281, 0.661985, 0.660692, 0.659402, 0.658114, 0.656828,
+-   0.655546, 0.654265, 0.652987, 0.651712, 0.650439, 0.649169, 0.647901, 0.646635,
+-   0.645372, 0.644112, 0.642854, 0.641598, 0.640345, 0.639095, 0.637846, 0.636601,
+-   0.635357, 0.634116, 0.632878, 0.631642, 0.630408, 0.629177, 0.627948, 0.626721,
+-   0.625497, 0.624276, 0.623056, 0.621839, 0.620625, 0.619413, 0.618203, 0.616996,
+-   0.615790, 0.614588, 0.613387, 0.612189, 0.610994, 0.609800, 0.608609, 0.607421,
+-   0.606234, 0.605050, 0.603868, 0.602689, 0.601512, 0.600337, 0.599165, 0.597994,
+-   0.596826, 0.595661, 0.594497, 0.593336, 0.592177, 0.591021, 0.589866, 0.588714,
+-   0.587564, 0.586417, 0.585272, 0.584128, 0.582988, 0.581849, 0.580712, 0.579578,
+-   0.578446, 0.577317, 0.576189, 0.575064, 0.573940, 0.572819, 0.571701, 0.570584,
+-   0.569470, 0.568357, 0.567247, 0.566139, 0.565034, 0.563930, 0.562829, 0.561729,
+-   0.560632, 0.559537, 0.558444, 0.557354, 0.556265, 0.555179, 0.554094, 0.553012,
+-   0.551932, 0.550854, 0.549778, 0.548704, 0.547633, 0.546563, 0.545496, 0.544430,
+-   0.543367, 0.542306, 0.541246, 0.540189, 0.539134, 0.538081, 0.537030, 0.535981,
+-   0.534935, 0.533890, 0.532847, 0.531806, 0.530768, 0.529731, 0.528696, 0.527664,
+-   0.526633, 0.525604, 0.524578, 0.523553, 0.522531, 0.521510, 0.520492, 0.519475,
+-   0.518460, 0.517448, 0.516437, 0.515429, 0.514422, 0.513417, 0.512414, 0.511414,
+-   0.510415, 0.509418, 0.508423, 0.507430, 0.506439, 0.505450, 0.504462, 0.503477,
+-   0.502494, 0.501512, 0.500533, 0.499555, 0.498580, 0.497606, 0.496634, 0.495664,
+-   0.494696, 0.493730, 0.492765, 0.491803, 0.490842, 0.489884, 0.488927, 0.487972,
+-   0.487019, 0.486068, 0.485118, 0.484171, 0.483225, 0.482281, 0.481339, 0.480399,
+-   0.479461, 0.478524, 0.477590, 0.476657, 0.475726, 0.474797, 0.473870, 0.472944,
+-   0.472020, 0.471098, 0.470178, 0.469260, 0.468343, 0.467429, 0.466516, 0.465605,
+-   0.464695, 0.463788, 0.462882, 0.461978, 0.461075, 0.460175, 0.459276, 0.458379,
+-   0.457484, 0.456590, 0.455699, 0.454809, 0.453920, 0.453034, 0.452149, 0.451266,
+-   0.450384, 0.449505, 0.448627, 0.447751, 0.446876, 0.446003, 0.445132, 0.444263,
+-   0.443395, 0.442529, 0.441665, 0.440802, 0.439941, 0.439082, 0.438224, 0.437368,
+-   0.436514, 0.435662, 0.434811, 0.433961, 0.433114, 0.432268, 0.431424, 0.430581,
+-   0.429740, 0.428901, 0.428063, 0.427227, 0.426393, 0.425560, 0.424729, 0.423899,
+-   0.423071, 0.422245, 0.421420, 0.420597, 0.419776, 0.418956, 0.418137, 0.417321,
+-   0.416506, 0.415692, 0.414880, 0.414070, 0.413261, 0.412454, 0.411648, 0.410844,
+-   0.410042, 0.409241, 0.408442, 0.407644, 0.406848, 0.406053, 0.405260, 0.404469,
+-   0.403679, 0.402890, 0.402103, 0.401318, 0.400534, 0.399752, 0.398971, 0.398192,
+-   0.397414, 0.396638, 0.395863, 0.395090, 0.394319, 0.393548, 0.392780, 0.392013,
+-   0.391247, 0.390483, 0.389720, 0.388959, 0.388199, 0.387441, 0.386684, 0.385929,
+-   0.385175, 0.384423, 0.383672, 0.382923, 0.382175, 0.381429, 0.380684, 0.379940,
+-   0.379198, 0.378457, 0.377718, 0.376980, 0.376244, 0.375509, 0.374776, 0.374044,
+-   0.373313, 0.372584, 0.371856, 0.371130, 0.370405, 0.369682, 0.368960, 0.368239,
+-   0.367520, 0.366802, 0.366086, 0.365371, 0.364657, 0.363945, 0.363234, 0.362525,
+-   0.361817, 0.361110, 0.360405, 0.359701, 0.358998, 0.358297, 0.357597, 0.356899,
+-   0.356202, 0.355506, 0.354812, 0.354119, 0.353427, 0.352737, 0.352048, 0.351360,
+-   0.350674, 0.349989, 0.349306, 0.348623, 0.347942, 0.347263, 0.346585, 0.345908,
+-   0.345232, 0.344558, 0.343885, 0.343213, 0.342543, 0.341874, 0.341206, 0.340540,
+-   0.339874, 0.339211, 0.338548, 0.337887, 0.337227, 0.336568, 0.335911, 0.335255,
+-   0.334600, 0.333947, 0.333294, 0.332643, 0.331994, 0.331345, 0.330698, 0.330052,
+-   0.329408, 0.328764, 0.328122, 0.327481, 0.326842, 0.326203, 0.325566, 0.324930,
+-   0.324296, 0.323662, 0.323030, 0.322399, 0.321770, 0.321141, 0.320514, 0.319888,
+-   0.319263, 0.318639, 0.318017, 0.317396, 0.316776, 0.316157, 0.315540, 0.314924,
+-   0.314309, 0.313695, 0.313082, 0.312470, 0.311860, 0.311251, 0.310643, 0.310036,
+-   0.309431, 0.308827, 0.308223, 0.307621, 0.307021, 0.306421, 0.305822, 0.305225,
+-   0.304629, 0.304034, 0.303440, 0.302847, 0.302256, 0.301666, 0.301076, 0.300488,
+-   0.299902, 0.299316, 0.298731, 0.298148, 0.297565, 0.296984, 0.296404, 0.295825,
+-   0.295247, 0.294671, 0.294095, 0.293521, 0.292948, 0.292375, 0.291804, 0.291234,
+-   0.290666, 0.290098, 0.289531, 0.288966, 0.288401, 0.287838, 0.287276, 0.286715,
+-   0.286155, 0.285596, 0.285038, 0.284482, 0.283926, 0.283371, 0.282818, 0.282266,
+-   0.281714, 0.281164, 0.280615, 0.280067, 0.279520, 0.278974, 0.278429, 0.277885,
+-   0.277342, 0.276801, 0.276260, 0.275721, 0.275182, 0.274645, 0.274108, 0.273573,
+-   0.273038, 0.272505, 0.271973, 0.271442, 0.270912, 0.270382, 0.269854, 0.269327,
+-   0.268801, 0.268276, 0.267752, 0.267229, 0.266707, 0.266186, 0.265667, 0.265148,
+-   0.264630, 0.264113, 0.263597, 0.263082, 0.262568, 0.262056, 0.261544, 0.261033,
+-   0.260523, 0.260014, 0.259506, 0.259000, 0.258494, 0.257989, 0.257485, 0.256982,
+-   0.256480, 0.255979, 0.255479, 0.254980, 0.254482, 0.253985, 0.253489, 0.252994,
+-   0.252500, 0.252007, 0.251515, 0.251023, 0.250533, 0.250044, 0.249555, 0.249068,
+-   0.248582, 0.248096, 0.247611, 0.247128, 0.246645, 0.246163, 0.245683, 0.245203,
+-   0.244724, 0.244246, 0.243769, 0.243293, 0.242818, 0.242343, 0.241870, 0.241398,
+-   0.240926, 0.240456, 0.239986, 0.239517, 0.239049, 0.238583, 0.238117, 0.237651,
+-   0.237187, 0.236724, 0.236262, 0.235800, 0.235340, 0.234880, 0.234421, 0.233963,
+-   0.233506, 0.233050, 0.232595, 0.232141, 0.231688, 0.231235, 0.230783, 0.230333,
+-   0.229883, 0.229434, 0.228986, 0.228538, 0.228092, 0.227647, 0.227202, 0.226758,
+-   0.226315, 0.225873, 0.225432, 0.224992, 0.224552, 0.224114, 0.223676, 0.223239,
+-   0.222803, 0.222368, 0.221934, 0.221500, 0.221068, 0.220636, 0.220205, 0.219775,
+-   0.219346, 0.218917, 0.218490, 0.218063, 0.217637, 0.217212, 0.216788, 0.216364,
+-   0.215942, 0.215520, 0.215099, 0.214679, 0.214260, 0.213841, 0.213423, 0.213007,
+-   0.212591, 0.212175, 0.211761, 0.211347, 0.210935, 0.210523, 0.210111, 0.209701,
+-   0.209291, 0.208883, 0.208475, 0.208068, 0.207661, 0.207256, 0.206851, 0.206447,
+-   0.206044, 0.205641, 0.205239, 0.204839, 0.204439, 0.204039, 0.203641, 0.203243,
+-   0.202846, 0.202450, 0.202054, 0.201660, 0.201266, 0.200873, 0.200481, 0.200089,
+-   0.199698, 0.199308, 0.198919, 0.198530, 0.198143, 0.197756, 0.197369, 0.196984,
+-   0.196599, 0.196215, 0.195832, 0.195449, 0.195068, 0.194687, 0.194306, 0.193927,
+-   0.193548, 0.193170, 0.192793, 0.192416, 0.192041, 0.191665, 0.191291, 0.190917,
+-   0.190545, 0.190172, 0.189801, 0.189430, 0.189060, 0.188691, 0.188323, 0.187955,
+-   0.187588, 0.187221, 0.186856, 0.186491, 0.186126, 0.185763, 0.185400, 0.185038,
+-   0.184676, 0.184316, 0.183956, 0.183597, 0.183238, 0.182880, 0.182523, 0.182166,
+-   0.181811, 0.181455, 0.181101, 0.180747, 0.180394, 0.180042, 0.179690, 0.179339,
+-   0.178989, 0.178640, 0.178291, 0.177942, 0.177595, 0.177248, 0.176902, 0.176556,
+-   0.176211, 0.175867, 0.175524, 0.175181, 0.174839, 0.174497, 0.174157, 0.173816,
+-   0.173477, 0.173138, 0.172800, 0.172462, 0.172126, 0.171789, 0.171454, 0.171119,
+-   0.170785, 0.170451, 0.170118, 0.169786, 0.169454, 0.169124, 0.168793, 0.168463,
+-   0.168134, 0.167806, 0.167478, 0.167151, 0.166825, 0.166499, 0.166174, 0.165849,
+-   0.165525, 0.165202, 0.164879, 0.164557, 0.164236, 0.163915, 0.163595, 0.163275,
+-   0.162957, 0.162638, 0.162321, 0.162004, 0.161687, 0.161371, 0.161056, 0.160742,
+-   0.160428, 0.160114, 0.159802, 0.159489, 0.159178, 0.158867, 0.158557, 0.158247,
+-   0.157938, 0.157630, 0.157322, 0.157014, 0.156708, 0.156402, 0.156096, 0.155791,
+-   0.155487, 0.155183, 0.154880, 0.154578, 0.154276, 0.153975, 0.153674, 0.153374,
+-   0.153074, 0.152775, 0.152477, 0.152179, 0.151882, 0.151585, 0.151289, 0.150994,
+-   0.150699, 0.150404, 0.150111, 0.149817, 0.149525, 0.149233, 0.148941, 0.148650,
+-   0.148360, 0.148070, 0.147781, 0.147492, 0.147204, 0.146917, 0.146630, 0.146344,
+-   0.146058, 0.145772, 0.145488, 0.145204, 0.144920, 0.144637, 0.144354, 0.144072,
+-   0.143791, 0.143510, 0.143230, 0.142950, 0.142671, 0.142392, 0.142114, 0.141837,
+-   0.141560, 0.141283, 0.141007, 0.140732, 0.140457, 0.140183, 0.139909, 0.139636,
+-   0.139363, 0.139091, 0.138819, 0.138548, 0.138277, 0.138007, 0.137738, 0.137469,
+-   0.137200, 0.136932, 0.136665, 0.136398, 0.136131, 0.135865, 0.135600, 0.135335,
+-};
+-
+-
+-const float *
+-lp_build_sample_aniso_filter_table(void)
+-{
+-   return aniso_filter_table;
+-}
+diff --git a/src/gallium/auxiliary/gallivm/lp_bld_sample.h b/src/gallium/auxiliary/gallivm/lp_bld_sample.h
+index 0b48c53e427..6c5ac2f9ffe 100644
+--- a/src/gallium/auxiliary/gallivm/lp_bld_sample.h
++++ b/src/gallium/auxiliary/gallivm/lp_bld_sample.h
+@@ -118,7 +118,6 @@ struct lp_sampler_params
+    const LLVMValueRef *offsets;
+    LLVMValueRef ms_index;
+    LLVMValueRef lod;
+-   LLVMValueRef aniso_filter_table;
+    const struct lp_derivatives *derivs;
+    LLVMValueRef *texel;
+ 
+@@ -512,8 +511,6 @@ struct lp_build_sample_context
+    LLVMTypeRef resources_type;
+    LLVMValueRef resources_ptr;
+ 
+-   LLVMValueRef aniso_filter_table;
+-
+    LLVMValueRef resident;
+ };
+ 
+@@ -794,7 +791,6 @@ lp_build_sample_soa_code(struct gallivm_state *gallivm,
+                          const struct lp_derivatives *derivs, /* optional */
+                          LLVMValueRef lod, /* optional */
+                          LLVMValueRef ms_index, /* optional */
+-                         LLVMValueRef aniso_filter_table,
+                          LLVMValueRef *texel_out);
+ 
+ 
+@@ -923,7 +919,6 @@ LLVMValueRef lp_sample_load_mip_value(struct gallivm_state *gallivm,
+                                       LLVMValueRef offsets,
+                                       LLVMValueRef index1);
+ 
+-const float *lp_build_sample_aniso_filter_table(void);
+ #ifdef __cplusplus
+ }
+ #endif
+diff --git a/src/gallium/auxiliary/gallivm/lp_bld_sample_soa.c b/src/gallium/auxiliary/gallivm/lp_bld_sample_soa.c
+index ec825ca342e..4b3212b19f1 100644
+--- a/src/gallium/auxiliary/gallivm/lp_bld_sample_soa.c
++++ b/src/gallium/auxiliary/gallivm/lp_bld_sample_soa.c
+@@ -2187,9 +2187,6 @@ lp_build_sample_ms_offset(struct lp_build_context *int_coord_bld,
+ 
+ static void
+ lp_build_sample_aniso(struct lp_build_sample_context *bld,
+-                      unsigned img_filter,
+-                      unsigned mip_filter,
+-                      bool is_gather,
+                       const LLVMValueRef *coords,
+                       const LLVMValueRef *offsets,
+                       LLVMValueRef ilevel0,
+@@ -2793,8 +2790,7 @@ lp_build_sample_general(struct lp_build_sample_context *bld,
+    }
+ 
+    if (sampler_state->aniso) {
+-      lp_build_sample_aniso(bld, PIPE_TEX_FILTER_NEAREST, mip_filter,
+-                            false, coords, offsets, ilevel0,
++      lp_build_sample_aniso(bld, coords, offsets, ilevel0,
+                             ilevel1, lod_fpart, texels);
+    } else if (min_filter == mag_filter) {
+       /* no need to distinguish between minification and magnification */
+@@ -3153,7 +3149,6 @@ lp_build_sample_soa_code(struct gallivm_state *gallivm,
+                          const struct lp_derivatives *derivs, /* optional */
+                          LLVMValueRef lod, /* optional */
+                          LLVMValueRef ms_index, /* optional */
+-                         LLVMValueRef aniso_filter_table,
+                          LLVMValueRef *texel_out)
+ {
+    assert(static_texture_state);
+@@ -3227,7 +3222,6 @@ lp_build_sample_soa_code(struct gallivm_state *gallivm,
+    bld.gallivm = gallivm;
+    bld.resources_type = resources_type;
+    bld.resources_ptr = resources_ptr;
+-   bld.aniso_filter_table = aniso_filter_table;
+    bld.static_sampler_state = &derived_sampler_state;
+    bld.static_texture_state = static_texture_state;
+    bld.dynamic_state = dynamic_state;
+@@ -3654,7 +3648,6 @@ lp_build_sample_soa_code(struct gallivm_state *gallivm,
+          bld4.gallivm = bld.gallivm;
+          bld4.resources_type = bld.resources_type;
+          bld4.resources_ptr = bld.resources_ptr;
+-         bld4.aniso_filter_table = aniso_filter_table;
+          bld4.static_texture_state = bld.static_texture_state;
+          bld4.static_sampler_state = bld.static_sampler_state;
+          bld4.dynamic_state = bld.dynamic_state;
+@@ -3858,8 +3851,7 @@ lp_build_sample_gen_func(struct gallivm_state *gallivm,
+                          unsigned sampler_index,
+                          LLVMValueRef function,
+                          unsigned num_args,
+-                         unsigned sample_key,
+-                         bool has_aniso_filter_table)
++                         unsigned sample_key)
+ {
+    LLVMBuilderRef old_builder;
+    LLVMBasicBlockRef block;
+@@ -3869,7 +3861,6 @@ lp_build_sample_gen_func(struct gallivm_state *gallivm,
+    LLVMValueRef ms_index = NULL;
+    LLVMValueRef resources_ptr;
+    LLVMValueRef thread_data_ptr = NULL;
+-   LLVMValueRef aniso_filter_table = NULL;
+    LLVMValueRef texel_out[4];
+    struct lp_derivatives derivs;
+    struct lp_derivatives *deriv_ptr = NULL;
+@@ -3901,8 +3892,6 @@ lp_build_sample_gen_func(struct gallivm_state *gallivm,
+ 
+    /* "unpack" arguments */
+    resources_ptr = LLVMGetParam(function, num_param++);
+-   if (has_aniso_filter_table)
+-      aniso_filter_table = LLVMGetParam(function, num_param++);
+    if (need_cache) {
+       thread_data_ptr = LLVMGetParam(function, num_param++);
+    }
+@@ -3966,7 +3955,6 @@ lp_build_sample_gen_func(struct gallivm_state *gallivm,
+                             deriv_ptr,
+                             lod,
+                             ms_index,
+-                            aniso_filter_table,
+                             texel_out);
+ 
+    LLVMBuildAggregateRet(gallivm->builder, texel_out, 4);
+@@ -4046,8 +4034,6 @@ lp_build_sample_soa_func(struct gallivm_state *gallivm,
+     */
+ 
+    arg_types[num_param++] = LLVMTypeOf(params->resources_ptr);
+-   if (params->aniso_filter_table)
+-      arg_types[num_param++] = LLVMTypeOf(params->aniso_filter_table);
+    if (need_cache) {
+       arg_types[num_param++] = LLVMTypeOf(params->thread_data_ptr);
+    }
+@@ -4112,14 +4098,11 @@ lp_build_sample_soa_func(struct gallivm_state *gallivm,
+                                sampler_index,
+                                function,
+                                num_param,
+-                               sample_key,
+-                               params->aniso_filter_table ? true : false);
++                               sample_key);
+    }
+ 
+    unsigned num_args = 0;
+    args[num_args++] = params->resources_ptr;
+-   if (params->aniso_filter_table)
+-      args[num_args++] = params->aniso_filter_table;
+    if (need_cache) {
+       args[num_args++] = params->thread_data_ptr;
+    }
+@@ -4236,7 +4219,6 @@ lp_build_sample_soa(const struct lp_static_texture_state *static_texture_state,
+                                params->derivs,
+                                params->lod,
+                                params->ms_index,
+-                               params->aniso_filter_table,
+                                params->texel);
+    }
+ }
+diff --git a/src/gallium/auxiliary/gallivm/lp_bld_tgsi.h b/src/gallium/auxiliary/gallivm/lp_bld_tgsi.h
+index dfa467aa2c0..28bfa0374ad 100644
+--- a/src/gallium/auxiliary/gallivm/lp_bld_tgsi.h
++++ b/src/gallium/auxiliary/gallivm/lp_bld_tgsi.h
+@@ -289,7 +289,6 @@ struct lp_build_tgsi_params {
+    LLVMValueRef kernel_args;
+    const struct lp_build_fs_iface *fs_iface;
+    unsigned gs_vertex_streams;
+-   LLVMValueRef aniso_filter_table;
+    LLVMValueRef current_func;
+    struct hash_table *fns;
+    LLVMValueRef scratch_ptr;
+diff --git a/src/gallium/drivers/llvmpipe/lp_jit.h b/src/gallium/drivers/llvmpipe/lp_jit.h
+index 006235e9f8f..672a42a103f 100644
+--- a/src/gallium/drivers/llvmpipe/lp_jit.h
++++ b/src/gallium/drivers/llvmpipe/lp_jit.h
+@@ -353,9 +353,6 @@ enum {
+ #define lp_jit_cs_context_images(_gallivm, _type, _ptr) \
+    lp_build_struct_get_ptr2(_gallivm, _type, _ptr, LP_JIT_CS_CTX_IMAGES, "images")
+ 
+-#define lp_jit_cs_context_aniso_filter_table(_gallivm, _type, _ptr) \
+-   lp_build_struct_get2(_gallivm, _type, _ptr, LP_JIT_CS_CTX_ANISO_FILTER_TABLE, "aniso_filter_table")
+-
+ #define lp_jit_cs_context_kernel_args(_gallivm, _type, _ptr) \
+    lp_build_struct_get2(_gallivm, _type, _ptr, LP_JIT_CS_CTX_KERNEL_ARGS, "kernel_args")
+ 
+diff --git a/src/gallium/drivers/llvmpipe/lp_setup.c b/src/gallium/drivers/llvmpipe/lp_setup.c
+index 6682f20a9e8..76ea2c807e0 100644
+--- a/src/gallium/drivers/llvmpipe/lp_setup.c
++++ b/src/gallium/drivers/llvmpipe/lp_setup.c
+@@ -1101,8 +1101,6 @@ try_update_scene_state(struct lp_setup_context *setup)
+                 &setup->fs.current.jit_resources,
+                 sizeof setup->fs.current.jit_resources);         
+ 
+-         stored->jit_resources.aniso_filter_table =
+-            lp_build_sample_aniso_filter_table();
+          stored->variant = setup->fs.current.variant;
+ 
+          if (!lp_scene_add_frag_shader_reference(scene,
+diff --git a/src/gallium/drivers/llvmpipe/lp_state_cs.c b/src/gallium/drivers/llvmpipe/lp_state_cs.c
+index 581b7638fa7..1ca054f4d2e 100644
+--- a/src/gallium/drivers/llvmpipe/lp_state_cs.c
++++ b/src/gallium/drivers/llvmpipe/lp_state_cs.c
+@@ -547,9 +547,6 @@ generate_compute(struct llvmpipe_context *lp,
+                                                   variant->jit_resources_type,
+                                                   params.resources_ptr);
+          params.image = image;
+-         params.aniso_filter_table = lp_jit_resources_aniso_filter_table(gallivm,
+-                                                                         variant->jit_resources_type,
+-                                                                         params.resources_ptr);
+ 
+          lp_build_nir_soa_func(gallivm, shader->base.ir.nir,
+                                func->impl,
+@@ -821,9 +818,6 @@ generate_compute(struct llvmpipe_context *lp,
+       params.payload_ptr = payload_ptr;
+       params.coro = &coro_info;
+       params.kernel_args = kernel_args_ptr;
+-      params.aniso_filter_table = lp_jit_resources_aniso_filter_table(gallivm,
+-                                                                      variant->jit_resources_type,
+-                                                                      resources_ptr);
+       params.mesh_iface = &mesh_iface.base;
+ 
+       params.current_func = NULL;
+@@ -1621,7 +1615,6 @@ llvmpipe_cs_update_derived(struct llvmpipe_context *llvmpipe, const void *input)
+                               llvmpipe->images[PIPE_SHADER_COMPUTE]);
+ 
+    struct lp_cs_context *csctx = llvmpipe->csctx;
+-   csctx->cs.current.jit_resources.aniso_filter_table = lp_build_sample_aniso_filter_table();
+    if (input) {
+       csctx->input = input;
+       csctx->cs.current.jit_context.kernel_args = input;
+@@ -2294,9 +2287,6 @@ llvmpipe_task_update_derived(struct llvmpipe_context *llvmpipe)
+       lp_csctx_set_cs_images(llvmpipe->task_ctx,
+                               ARRAY_SIZE(llvmpipe->images[PIPE_SHADER_TASK]),
+                               llvmpipe->images[PIPE_SHADER_TASK]);
+-
+-   struct lp_cs_context *csctx = llvmpipe->task_ctx;
+-   csctx->cs.current.jit_resources.aniso_filter_table = lp_build_sample_aniso_filter_table();
+ }
+ 
+ void
+@@ -2330,7 +2320,4 @@ llvmpipe_mesh_update_derived(struct llvmpipe_context *llvmpipe)
+       lp_csctx_set_cs_images(llvmpipe->mesh_ctx,
+                               ARRAY_SIZE(llvmpipe->images[PIPE_SHADER_MESH]),
+                               llvmpipe->images[PIPE_SHADER_MESH]);
+-
+-   struct lp_cs_context *csctx = llvmpipe->mesh_ctx;
+-   csctx->cs.current.jit_resources.aniso_filter_table = lp_build_sample_aniso_filter_table();
+ }
+diff --git a/src/gallium/drivers/llvmpipe/lp_state_fs.c b/src/gallium/drivers/llvmpipe/lp_state_fs.c
+index ac2cd933cf3..5414c6edfe0 100644
+--- a/src/gallium/drivers/llvmpipe/lp_state_fs.c
++++ b/src/gallium/drivers/llvmpipe/lp_state_fs.c
+@@ -1101,7 +1101,6 @@ generate_fs_loop(struct gallivm_state *gallivm,
+    params.info = &shader->info.base;
+    params.ssbo_ptr = ssbo_ptr;
+    params.image = image;
+-   params.aniso_filter_table = lp_jit_resources_aniso_filter_table(gallivm, resources_type, resources_ptr);
+ 
+    /* Build the actual shader */
+    lp_build_nir_soa(gallivm, nir, &params, outputs);
+diff --git a/src/gallium/drivers/llvmpipe/lp_texture_handle.c b/src/gallium/drivers/llvmpipe/lp_texture_handle.c
+index cc82119be67..4f68d87b785 100644
+--- a/src/gallium/drivers/llvmpipe/lp_texture_handle.c
++++ b/src/gallium/drivers/llvmpipe/lp_texture_handle.c
+@@ -495,8 +495,6 @@ compile_sample_function(struct llvmpipe_context *ctx, struct lp_static_texture_s
+    gallivm->texture_descriptor = LLVMGetParam(function, arg_index++);
+    gallivm->sampler_descriptor = LLVMGetParam(function, arg_index++);
+ 
+-   LLVMValueRef aniso_filter_table = LLVMGetParam(function, arg_index++);
+-
+    LLVMValueRef coords[5];
+    for (unsigned i = 0; i < 4; i++)
+       coords[i] = LLVMGetParam(function, arg_index++);
+@@ -528,7 +526,7 @@ compile_sample_function(struct llvmpipe_context *ctx, struct lp_static_texture_s
+    if (supported) {
+       lp_build_sample_soa_code(gallivm, texture, sampler, lp_build_sampler_soa_dynamic_state(sampler_soa),
+                                type, sample_key, 0, 0, cs.jit_resources_type, NULL, cs.jit_cs_thread_data_type,
+-                               NULL, coords, offsets, NULL, lod, ms_index, aniso_filter_table, texel_out);
++                               NULL, coords, offsets, NULL, lod, ms_index, texel_out);
+    } else {
+       lp_build_sample_nop(gallivm, lp_build_texel_type(type, util_format_description(texture->format)), coords, texel_out);
+    }
+-- 
+2.34.1
+

--- a/meta-flex-staging/recipes-graphics/mesa/files/0004-llvmpipe-Move-max_anisotropy-to-static-sampler-state.patch
+++ b/meta-flex-staging/recipes-graphics/mesa/files/0004-llvmpipe-Move-max_anisotropy-to-static-sampler-state.patch
@@ -1,0 +1,263 @@
+From 9aee5834af55430b3909d9016be8ea7ea76d131c Mon Sep 17 00:00:00 2001
+From: Konstantin Seurer <konstantin.seurer@gmail.com>
+Date: Wed, 13 Nov 2024 21:53:02 +0100
+Subject: [PATCH 4/9] llvmpipe: Move max_anisotropy to static sampler state
+
+Applications typically use one globak max_anisotropy value.
+Moving it to static state should save a could of instructions.
+
+Reviewed-by: Aleksi Sapon <aleksi.sapon@autodesk.com>
+Reviewed-by: Adam Jackson <ajax@redhat.com>
+Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/31748>
+
+Upstream-Status: Backport [https://gitlab.freedesktop.org/mesa/mesa/-/commit/378fd38e1da44e3a565a49a1195388542a7b54ca]
+---
+ src/gallium/auxiliary/draw/draw_llvm.c         |  1 -
+ .../auxiliary/gallivm/lp_bld_jit_types.c       |  8 +-------
+ .../auxiliary/gallivm/lp_bld_jit_types.h       |  2 --
+ src/gallium/auxiliary/gallivm/lp_bld_sample.c  | 18 +++++++++---------
+ src/gallium/auxiliary/gallivm/lp_bld_sample.h  | 10 +---------
+ .../auxiliary/gallivm/lp_bld_sample_soa.c      | 12 ++----------
+ src/gallium/drivers/llvmpipe/lp_jit.c          |  1 -
+ src/gallium/drivers/llvmpipe/lp_state_cs.c     |  1 -
+ 8 files changed, 13 insertions(+), 40 deletions(-)
+
+diff --git a/src/gallium/auxiliary/draw/draw_llvm.c b/src/gallium/auxiliary/draw/draw_llvm.c
+index 40ed7cd0bc4..59220f6eaaa 100644
+--- a/src/gallium/auxiliary/draw/draw_llvm.c
++++ b/src/gallium/auxiliary/draw/draw_llvm.c
+@@ -2223,7 +2223,6 @@ draw_llvm_set_sampler_state(struct draw_context *draw,
+          jit_sam->min_lod = s->min_lod;
+          jit_sam->max_lod = s->max_lod;
+          jit_sam->lod_bias = s->lod_bias;
+-         jit_sam->max_aniso = s->max_anisotropy;
+          COPY_4V(jit_sam->border_color, s->border_color.f);
+       }
+    }
+diff --git a/src/gallium/auxiliary/gallivm/lp_bld_jit_types.c b/src/gallium/auxiliary/gallivm/lp_bld_jit_types.c
+index 22d5266d219..8e2651dd404 100644
+--- a/src/gallium/auxiliary/gallivm/lp_bld_jit_types.c
++++ b/src/gallium/auxiliary/gallivm/lp_bld_jit_types.c
+@@ -201,8 +201,7 @@ lp_build_create_jit_sampler_type(struct gallivm_state *gallivm)
+    LLVMTypeRef elem_types[LP_JIT_SAMPLER_NUM_FIELDS];
+    elem_types[LP_JIT_SAMPLER_MIN_LOD] =
+    elem_types[LP_JIT_SAMPLER_MAX_LOD] =
+-   elem_types[LP_JIT_SAMPLER_LOD_BIAS] =
+-   elem_types[LP_JIT_SAMPLER_MAX_ANISO] = LLVMFloatTypeInContext(lc);
++   elem_types[LP_JIT_SAMPLER_LOD_BIAS] = LLVMFloatTypeInContext(lc);
+    elem_types[LP_JIT_SAMPLER_BORDER_COLOR] =
+       LLVMArrayType(LLVMFloatTypeInContext(lc), 4);
+ 
+@@ -221,9 +220,6 @@ lp_build_create_jit_sampler_type(struct gallivm_state *gallivm)
+    LP_CHECK_MEMBER_OFFSET(struct lp_jit_sampler, border_color,
+                           gallivm->target, sampler_type,
+                           LP_JIT_SAMPLER_BORDER_COLOR);
+-   LP_CHECK_MEMBER_OFFSET(struct lp_jit_sampler, max_aniso,
+-                          gallivm->target, sampler_type,
+-                          LP_JIT_SAMPLER_MAX_ANISO);
+    LP_CHECK_STRUCT_SIZE(struct lp_jit_sampler,
+                         gallivm->target, sampler_type);
+    return sampler_type;
+@@ -566,7 +562,6 @@ LP_BUILD_LLVM_SAMPLER_MEMBER(min_lod,    LP_JIT_SAMPLER_MIN_LOD, true)
+ LP_BUILD_LLVM_SAMPLER_MEMBER(max_lod,    LP_JIT_SAMPLER_MAX_LOD, true)
+ LP_BUILD_LLVM_SAMPLER_MEMBER(lod_bias,   LP_JIT_SAMPLER_LOD_BIAS, true)
+ LP_BUILD_LLVM_SAMPLER_MEMBER(border_color, LP_JIT_SAMPLER_BORDER_COLOR, false)
+-LP_BUILD_LLVM_SAMPLER_MEMBER(max_aniso, LP_JIT_SAMPLER_MAX_ANISO, true)
+ 
+ /**
+  * Fetch the specified member of the lp_jit_image structure.
+@@ -703,7 +698,6 @@ lp_build_jit_fill_sampler_dynamic_state(struct lp_sampler_dynamic_state *state)
+    state->max_lod = lp_build_llvm_sampler_max_lod;
+    state->lod_bias = lp_build_llvm_sampler_lod_bias;
+    state->border_color = lp_build_llvm_sampler_border_color;
+-   state->max_aniso = lp_build_llvm_sampler_max_aniso;
+ }
+ 
+ void
+diff --git a/src/gallium/auxiliary/gallivm/lp_bld_jit_types.h b/src/gallium/auxiliary/gallivm/lp_bld_jit_types.h
+index b8d3c897dfa..249950d5ec1 100644
+--- a/src/gallium/auxiliary/gallivm/lp_bld_jit_types.h
++++ b/src/gallium/auxiliary/gallivm/lp_bld_jit_types.h
+@@ -101,7 +101,6 @@ struct lp_jit_sampler
+    float max_lod;
+    float lod_bias;
+    float border_color[4];
+-   float max_aniso;
+ };
+ 
+ enum {
+@@ -109,7 +108,6 @@ enum {
+    LP_JIT_SAMPLER_MAX_LOD,
+    LP_JIT_SAMPLER_LOD_BIAS,
+    LP_JIT_SAMPLER_BORDER_COLOR,
+-   LP_JIT_SAMPLER_MAX_ANISO,
+    LP_JIT_SAMPLER_NUM_FIELDS  /* number of fields above */
+ };
+ 
+diff --git a/src/gallium/auxiliary/gallivm/lp_bld_sample.c b/src/gallium/auxiliary/gallivm/lp_bld_sample.c
+index 1f0e5818fe0..4fafb5d3be6 100644
+--- a/src/gallium/auxiliary/gallivm/lp_bld_sample.c
++++ b/src/gallium/auxiliary/gallivm/lp_bld_sample.c
+@@ -220,7 +220,8 @@ lp_sampler_static_sampler_state(struct lp_static_sampler_state *state,
+    state->min_mip_filter    = sampler->min_mip_filter;
+    state->seamless_cube_map = sampler->seamless_cube_map;
+    state->reduction_mode    = sampler->reduction_mode;
+-   state->aniso = sampler->max_anisotropy > 1.0f;
++   if (sampler->max_anisotropy > 1)
++      state->aniso = sampler->max_anisotropy;
+ 
+    if (sampler->max_lod > 0.0f) {
+       state->max_lod_pos = 1;
+@@ -267,8 +268,7 @@ static LLVMValueRef
+ lp_build_pmin(struct lp_build_sample_context *bld,
+               LLVMValueRef first_level,
+               LLVMValueRef s,
+-              LLVMValueRef t,
+-              LLVMValueRef max_aniso)
++              LLVMValueRef t)
+ {
+    struct gallivm_state *gallivm = bld->gallivm;
+    LLVMBuilderRef builder = bld->gallivm->builder;
+@@ -287,8 +287,6 @@ lp_build_pmin(struct lp_build_sample_context *bld,
+ 
+    int_size = lp_build_minify(int_size_bld, bld->int_size, first_level, true);
+    float_size = lp_build_int_to_float(float_size_bld, int_size);
+-   max_aniso = lp_build_broadcast_scalar(coord_bld, max_aniso);
+-   max_aniso = lp_build_mul(coord_bld, max_aniso, max_aniso);
+ 
+    static const unsigned char swizzle01[] = { /* no-op swizzle */
+       0, 1,
+@@ -329,12 +327,15 @@ lp_build_pmin(struct lp_build_sample_context *bld,
+    LLVMValueRef pmax2 = lp_build_max(coord_bld, px2, py2);
+    LLVMValueRef pmin2 = lp_build_min(coord_bld, px2, py2);
+ 
+-   LLVMValueRef temp = lp_build_mul(coord_bld, pmin2, max_aniso);
++   LLVMValueRef temp = lp_build_mul(
++      coord_bld, pmin2, lp_build_const_vec(gallivm, coord_bld->type, bld->static_sampler_state->aniso *
++                                           bld->static_sampler_state->aniso));
+ 
+    LLVMValueRef comp = lp_build_compare(gallivm, coord_bld->type, PIPE_FUNC_GREATER,
+                                         pmax2, temp);
+ 
+-   LLVMValueRef pmin2_alt = lp_build_div(coord_bld, pmax2, max_aniso);
++   LLVMValueRef pmin2_alt = lp_build_div(coord_bld, pmax2,
++      lp_build_const_vec(gallivm, coord_bld->type, bld->static_sampler_state->aniso));
+ 
+    pmin2 = lp_build_select(coord_bld, comp, pmin2_alt, pmin2);
+ 
+@@ -815,7 +816,6 @@ lp_build_lod_selector(struct lp_build_sample_context *bld,
+                       LLVMValueRef lod_bias, /* optional */
+                       LLVMValueRef explicit_lod, /* optional */
+                       enum pipe_tex_mipfilter mip_filter,
+-                      LLVMValueRef max_aniso,
+                       LLVMValueRef *out_lod,
+                       LLVMValueRef *out_lod_ipart,
+                       LLVMValueRef *out_lod_fpart,
+@@ -871,7 +871,7 @@ lp_build_lod_selector(struct lp_build_sample_context *bld,
+ 
+          if (bld->static_sampler_state->aniso &&
+              !explicit_lod) {
+-            rho = lp_build_pmin(bld, first_level, s, t, max_aniso);
++            rho = lp_build_pmin(bld, first_level, s, t);
+             rho_squared = true;
+          } else {
+             rho = lp_build_rho(bld, first_level, s, t, r, derivs);
+diff --git a/src/gallium/auxiliary/gallivm/lp_bld_sample.h b/src/gallium/auxiliary/gallivm/lp_bld_sample.h
+index 6c5ac2f9ffe..f6612e03a0e 100644
+--- a/src/gallium/auxiliary/gallivm/lp_bld_sample.h
++++ b/src/gallium/auxiliary/gallivm/lp_bld_sample.h
+@@ -230,7 +230,7 @@ struct lp_static_sampler_state
+    unsigned apply_min_lod:1;  /**< min_lod > 0 ? */
+    unsigned apply_max_lod:1;  /**< max_lod < last_level ? */
+    unsigned seamless_cube_map:1;
+-   unsigned aniso:1;
++   unsigned aniso:5;
+    unsigned reduction_mode:2;
+ };
+ 
+@@ -359,13 +359,6 @@ struct lp_sampler_dynamic_state
+                    LLVMValueRef resources_ptr,
+                    unsigned sampler_unit);
+ 
+-   /** Obtain maximum anisotropy */
+-   LLVMValueRef
+-   (*max_aniso)(struct gallivm_state *gallivm,
+-                LLVMTypeRef resources_type,
+-                LLVMValueRef resources_ptr,
+-                unsigned sampler_unit);
+-
+    /**
+     * Obtain texture cache (returns ptr to lp_build_format_cache).
+     *
+@@ -646,7 +639,6 @@ lp_build_lod_selector(struct lp_build_sample_context *bld,
+                       LLVMValueRef lod_bias, /* optional */
+                       LLVMValueRef explicit_lod, /* optional */
+                       enum pipe_tex_mipfilter mip_filter,
+-                      LLVMValueRef max_aniso,
+                       LLVMValueRef *out_lod,
+                       LLVMValueRef *out_lod_ipart,
+                       LLVMValueRef *out_lod_fpart,
+diff --git a/src/gallium/auxiliary/gallivm/lp_bld_sample_soa.c b/src/gallium/auxiliary/gallivm/lp_bld_sample_soa.c
+index 4b3212b19f1..69ec61e9a52 100644
+--- a/src/gallium/auxiliary/gallivm/lp_bld_sample_soa.c
++++ b/src/gallium/auxiliary/gallivm/lp_bld_sample_soa.c
+@@ -2243,7 +2243,7 @@ lp_build_sample_aniso(struct lp_build_sample_context *bld,
+ 
+    /* Number of samples used for averaging. */
+    LLVMValueRef N = lp_build_iceil(coord_bld, lp_build_max(coord_bld, rho_x, rho_y));
+-   N = lp_build_min(int_coord_bld, N, lp_build_const_int_vec(gallivm, int_coord_bld->type, 16));
++   N = lp_build_min(int_coord_bld, N, lp_build_const_int_vec(gallivm, int_coord_bld->type, bld->static_sampler_state->aniso));
+    LLVMValueRef wave_max_N = NULL;
+    for (uint32_t i = 0; i < coord_bld->type.length; i++) {
+       LLVMValueRef invocation_N = LLVMBuildExtractElement(builder, N, lp_build_const_int32(gallivm, i), "");
+@@ -2424,14 +2424,6 @@ lp_build_sample_common(struct lp_build_sample_context *bld,
+     */
+    if (min_filter != mag_filter ||
+        mip_filter != PIPE_TEX_MIPFILTER_NONE || is_lodq) {
+-      LLVMValueRef max_aniso = NULL;
+-
+-      if (aniso)
+-         max_aniso = bld->dynamic_state->max_aniso(bld->gallivm,
+-                                                   bld->resources_type,
+-                                                   bld->resources_ptr,
+-                                                   sampler_index);
+-
+       /* Need to compute lod either to choose mipmap levels or to
+        * distinguish between minification/magnification with one mipmap level.
+        */
+@@ -2441,7 +2433,7 @@ lp_build_sample_common(struct lp_build_sample_context *bld,
+                             first_level_vec,
+                             coords[0], coords[1], coords[2],
+                             derivs, lod_bias, explicit_lod,
+-                            mip_filter, max_aniso, lod,
++                            mip_filter, lod,
+                             &lod_ipart, lod_fpart, lod_pos_or_zero);
+       if (is_lodq) {
+          last_level = lp_build_sub(&bld->int_bld, last_level, first_level);
+diff --git a/src/gallium/drivers/llvmpipe/lp_jit.c b/src/gallium/drivers/llvmpipe/lp_jit.c
+index bc52a0d5b56..851772f7be2 100644
+--- a/src/gallium/drivers/llvmpipe/lp_jit.c
++++ b/src/gallium/drivers/llvmpipe/lp_jit.c
+@@ -546,7 +546,6 @@ lp_jit_sampler_from_pipe(struct lp_jit_sampler *jit, const struct pipe_sampler_s
+    jit->min_lod = sampler->min_lod;
+    jit->max_lod = sampler->max_lod;
+    jit->lod_bias = sampler->lod_bias;
+-   jit->max_aniso = sampler->max_anisotropy;
+    COPY_4V(jit->border_color, sampler->border_color.f);
+ }
+ 
+diff --git a/src/gallium/drivers/llvmpipe/lp_state_cs.c b/src/gallium/drivers/llvmpipe/lp_state_cs.c
+index 1ca054f4d2e..fe2fa0f319b 100644
+--- a/src/gallium/drivers/llvmpipe/lp_state_cs.c
++++ b/src/gallium/drivers/llvmpipe/lp_state_cs.c
+@@ -1470,7 +1470,6 @@ lp_csctx_set_sampler_state(struct lp_cs_context *csctx,
+          jit_sam->min_lod = sampler->min_lod;
+          jit_sam->max_lod = sampler->max_lod;
+          jit_sam->lod_bias = sampler->lod_bias;
+-         jit_sam->max_aniso = sampler->max_anisotropy;
+          COPY_4V(jit_sam->border_color, sampler->border_color.f);
+       }
+    }
+-- 
+2.34.1
+

--- a/meta-flex-staging/recipes-graphics/mesa/files/0005-llvmpipe-disable-anisotropic-filtering-for-non-2D-te.patch
+++ b/meta-flex-staging/recipes-graphics/mesa/files/0005-llvmpipe-disable-anisotropic-filtering-for-non-2D-te.patch
@@ -1,0 +1,48 @@
+From 8acc11cd83c715bd49f7ce383b3baa05b96630c8 Mon Sep 17 00:00:00 2001
+From: Aleksi Sapon <aleksi.sapon@autodesk.com>
+Date: Fri, 17 Jan 2025 16:16:13 -0500
+Subject: [PATCH 5/9] llvmpipe: disable anisotropic filtering for non-2D
+ textures
+
+Reviewed-by: Konstantin Seurer <konstantin.seurer@gmail.com>
+Reviewed-by: Roland Scheidegger <roland.scheidegger@broadcom.com>
+Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/33103>
+
+Upstream-Status: Backport [https://gitlab.freedesktop.org/mesa/mesa/-/commit/43ff387aa62edf747d1728606f0fa137877df60c]
+---
+ src/gallium/auxiliary/gallivm/lp_bld_sample_soa.c | 4 ++++
+ src/gallium/drivers/llvmpipe/lp_texture_handle.c  | 3 ---
+ 2 files changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/src/gallium/auxiliary/gallivm/lp_bld_sample_soa.c b/src/gallium/auxiliary/gallivm/lp_bld_sample_soa.c
+index 69ec61e9a52..c0a1a140415 100644
+--- a/src/gallium/auxiliary/gallivm/lp_bld_sample_soa.c
++++ b/src/gallium/auxiliary/gallivm/lp_bld_sample_soa.c
+@@ -3207,6 +3207,10 @@ lp_build_sample_soa_code(struct gallivm_state *gallivm,
+       return;
+    }
+ 
++   if (texture_dims(target) != 2) {
++      derived_sampler_state.aniso = 0;
++   }
++
+    assert(type.floating);
+ 
+    /* Setup our build context */
+diff --git a/src/gallium/drivers/llvmpipe/lp_texture_handle.c b/src/gallium/drivers/llvmpipe/lp_texture_handle.c
+index 4f68d87b785..c6accb190b4 100644
+--- a/src/gallium/drivers/llvmpipe/lp_texture_handle.c
++++ b/src/gallium/drivers/llvmpipe/lp_texture_handle.c
+@@ -440,9 +440,6 @@ compile_sample_function(struct llvmpipe_context *ctx, struct lp_static_texture_s
+          supported = false;
+ 
+       if (sampler->aniso) {
+-         if (texture_dims(texture->target) != 2)
+-            supported = false;
+-
+          if (util_format_is_pure_integer(texture->format))
+             supported = false;
+       }
+-- 
+2.34.1
+

--- a/meta-flex-staging/recipes-graphics/mesa/files/0006-llvmpipe-Fix-half-pixel-sample-offset-with-AF.patch
+++ b/meta-flex-staging/recipes-graphics/mesa/files/0006-llvmpipe-Fix-half-pixel-sample-offset-with-AF.patch
@@ -1,0 +1,43 @@
+From 2c349955b78316d13eee3997fc691bf8827c7917 Mon Sep 17 00:00:00 2001
+From: Konstantin Seurer <konstantin.seurer@gmail.com>
+Date: Tue, 7 Jan 2025 21:20:42 +0100
+Subject: [PATCH 6/9] llvmpipe: Fix half-pixel sample offset with AF
+
+Simply adding -0.5 will cause a noticeable offset for low sample counts.
+
+Reviewed-by: Aleksi Sapon <aleksi.sapon@autodesk.com>
+Acked-by: Mike Blumenkrantz <michael.blumenkrantz@gmail.com>
+Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/32935>
+
+Upstream-Status: Backport [https://gitlab.freedesktop.org/mesa/mesa/-/commit/3f7564d86b1213eb2d54142a73f6e89d72ecd610]
+---
+ src/gallium/auxiliary/gallivm/lp_bld_sample_soa.c   | 4 +++-
+ src/gallium/drivers/llvmpipe/ci/traces-llvmpipe.yml | 6 +++---
+ 2 files changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/src/gallium/auxiliary/gallivm/lp_bld_sample_soa.c b/src/gallium/auxiliary/gallivm/lp_bld_sample_soa.c
+index c0a1a140415..50f96544da1 100644
+--- a/src/gallium/auxiliary/gallivm/lp_bld_sample_soa.c
++++ b/src/gallium/auxiliary/gallivm/lp_bld_sample_soa.c
+@@ -2266,6 +2266,8 @@ lp_build_sample_aniso(struct lp_build_sample_context *bld,
+ 
+    LLVMValueRef float_N = lp_build_int_to_float(coord_bld, N);
+    LLVMValueRef rcp_N = lp_build_rcp(coord_bld, float_N);
++   LLVMValueRef base_k = LLVMBuildFMul(builder, float_N, lp_build_const_vec(gallivm, coord_bld->type, -0.5), "");
++   base_k = lp_build_add(coord_bld, base_k, lp_build_const_vec(gallivm, coord_bld->type, 0.5));
+ 
+    struct lp_build_for_loop_state loop_state;
+    lp_build_for_loop_begin(&loop_state, gallivm, lp_build_const_int32(gallivm, 0),
+@@ -2275,8 +2277,8 @@ lp_build_sample_aniso(struct lp_build_sample_context *bld,
+       k = lp_build_broadcast_scalar(int_coord_bld, k);
+ 
+       LLVMValueRef float_k = lp_build_int_to_float(coord_bld, k);
++      float_k = lp_build_add(coord_bld, float_k, base_k);
+       float_k = lp_build_mul(coord_bld, float_k, rcp_N);
+-      float_k = lp_build_add(coord_bld, float_k, lp_build_const_vec(gallivm, coord_bld->type, -0.5));
+ 
+       LLVMValueRef u_offset = lp_build_mul(coord_bld, float_k, dudk);
+       LLVMValueRef v_offset = lp_build_mul(coord_bld, float_k, dvdk);
+-- 
+2.34.1
+

--- a/meta-flex-staging/recipes-graphics/mesa/files/0007-llvmpipe-Avoid-a-crash-when-using-5-coords-with-AF.patch
+++ b/meta-flex-staging/recipes-graphics/mesa/files/0007-llvmpipe-Avoid-a-crash-when-using-5-coords-with-AF.patch
@@ -1,0 +1,37 @@
+From 23a52bb96b2c950d738f9b533f36131ad5f0d49c Mon Sep 17 00:00:00 2001
+From: Konstantin Seurer <konstantin.seurer@gmail.com>
+Date: Mon, 13 Jan 2025 19:51:33 +0100
+Subject: [PATCH 7/9] llvmpipe: Avoid a crash when using 5 coords with AF
+
+Acked-by: Mike Blumenkrantz <michael.blumenkrantz@gmail.com>
+Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/32935>
+
+Upstream-Status: Backport [https://gitlab.freedesktop.org/mesa/mesa/-/commit/6701806cd1f97eb22e23a10ea9440935fd437178]
+---
+ src/gallium/auxiliary/gallivm/lp_bld_sample_soa.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/src/gallium/auxiliary/gallivm/lp_bld_sample_soa.c b/src/gallium/auxiliary/gallivm/lp_bld_sample_soa.c
+index 50f96544da1..9c7ed784e34 100644
+--- a/src/gallium/auxiliary/gallivm/lp_bld_sample_soa.c
++++ b/src/gallium/auxiliary/gallivm/lp_bld_sample_soa.c
+@@ -2283,12 +2283,13 @@ lp_build_sample_aniso(struct lp_build_sample_context *bld,
+       LLVMValueRef u_offset = lp_build_mul(coord_bld, float_k, dudk);
+       LLVMValueRef v_offset = lp_build_mul(coord_bld, float_k, dvdk);
+ 
+-      LLVMValueRef sample_coords[4] = {
++      LLVMValueRef sample_coords[5] = {
+          lp_build_add(coord_bld, coords[0], u_offset),
+          lp_build_add(coord_bld, coords[1], v_offset),
+-         coords[2],
+-         coords[3],
+       };
++      for (uint32_t i = 2; i < ARRAY_SIZE(sample_coords); i++)
++         sample_coords[i] = coords[i];
++
+ 
+       if (bld->static_texture_state->target == PIPE_TEXTURE_CUBE ||
+           bld->static_texture_state->target == PIPE_TEXTURE_CUBE_ARRAY) {
+-- 
+2.34.1
+

--- a/meta-flex-staging/recipes-graphics/mesa/files/0008-llvmpipe-Fix-overflow-issues-calculating-loop-iterat.patch
+++ b/meta-flex-staging/recipes-graphics/mesa/files/0008-llvmpipe-Fix-overflow-issues-calculating-loop-iterat.patch
@@ -1,0 +1,56 @@
+From a0bfe8ad9235743bf1d75f37185f822f71f07407 Mon Sep 17 00:00:00 2001
+From: Roland Scheidegger <roland.scheidegger@broadcom.com>
+Date: Thu, 13 Feb 2025 23:38:48 +0100
+Subject: [PATCH 8/9] llvmpipe: Fix overflow issues calculating loop
+ iterations for aniso
+
+iceil can return bogus (negative) values in case there's an overflow
+(or a NaN). This would then take forever to run due to a couple billion
+loop iterations.
+Use unsigned minimum instead which will clamp iterations to max aniso
+(not sure if that makes more sense than clamping negative values to 0,
+probably doesn't really matter).
+
+Fixes: 350a0fe63298 ("llvmpipe: Use a simpler and faster AF implementation")
+
+Reviewed-by: Brian Paul <brian.paul@broadcom.com>
+Reviewed-by: Konstantin Seurer <konstantin.seurer@gmail.com>
+Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/33537>
+
+Upstream-Status: Backport [https://gitlab.freedesktop.org/mesa/mesa/-/commit/24076eb3f9d1518710df7b534c863dc85668a5fe]
+---
+ src/gallium/auxiliary/gallivm/lp_bld_sample_soa.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/src/gallium/auxiliary/gallivm/lp_bld_sample_soa.c b/src/gallium/auxiliary/gallivm/lp_bld_sample_soa.c
+index 9c7ed784e34..89e6388f0c6 100644
+--- a/src/gallium/auxiliary/gallivm/lp_bld_sample_soa.c
++++ b/src/gallium/auxiliary/gallivm/lp_bld_sample_soa.c
+@@ -2198,9 +2198,13 @@ lp_build_sample_aniso(struct lp_build_sample_context *bld,
+    LLVMBuilderRef builder = gallivm->builder;
+    struct lp_build_context *coord_bld = &bld->coord_bld;
+    struct lp_build_context *int_coord_bld = &bld->int_coord_bld;
++   struct lp_build_context uint_coord_bld;
++
+    LLVMValueRef size0, row_stride0_vec, img_stride0_vec;
+    LLVMValueRef data_ptr0, mipoff0 = NULL;
+ 
++   lp_build_context_init(&uint_coord_bld, gallivm, lp_uint_type(int_coord_bld->type));
++
+    lp_build_mipmap_level_sizes(bld, ilevel0,
+                                &size0,
+                                &row_stride0_vec, &img_stride0_vec);
+@@ -2243,7 +2247,9 @@ lp_build_sample_aniso(struct lp_build_sample_context *bld,
+ 
+    /* Number of samples used for averaging. */
+    LLVMValueRef N = lp_build_iceil(coord_bld, lp_build_max(coord_bld, rho_x, rho_y));
+-   N = lp_build_min(int_coord_bld, N, lp_build_const_int_vec(gallivm, int_coord_bld->type, bld->static_sampler_state->aniso));
++
++   /* Use uint min so in case of NaNs/overflows loop iterations are clamped to max aniso */
++   N = lp_build_min(&uint_coord_bld, N, lp_build_const_int_vec(gallivm, int_coord_bld->type, bld->static_sampler_state->aniso));
+    LLVMValueRef wave_max_N = NULL;
+    for (uint32_t i = 0; i < coord_bld->type.length; i++) {
+       LLVMValueRef invocation_N = LLVMBuildExtractElement(builder, N, lp_build_const_int32(gallivm, i), "");
+-- 
+2.34.1
+

--- a/meta-flex-staging/recipes-graphics/mesa/files/0009-llvmpipe-improve-aniso-filtering.patch
+++ b/meta-flex-staging/recipes-graphics/mesa/files/0009-llvmpipe-improve-aniso-filtering.patch
@@ -1,0 +1,652 @@
+From 34a4f9b9774cd8064631f5521a3509d8e1106360 Mon Sep 17 00:00:00 2001
+From: Aleksi Sapon <aleksi.sapon@autodesk.com>
+Date: Tue, 8 Apr 2025 16:24:57 -0400
+Subject: [PATCH 9/9] llvmpipe: improve aniso filtering
+
+Reviewed-by: Konstantin Seurer <konstantin.seurer@gmail.com>
+Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/34438>
+
+Upstream-Status: Backport [https://gitlab.freedesktop.org/mesa/mesa/-/commit/9301b7098abfd3a7393604bb81aa29cb0036487f]
+---
+ src/gallium/auxiliary/gallivm/lp_bld_arit.c   |  20 +++
+ src/gallium/auxiliary/gallivm/lp_bld_arit.h   |   6 +
+ src/gallium/auxiliary/gallivm/lp_bld_sample.c | 105 +++++++-----
+ src/gallium/auxiliary/gallivm/lp_bld_sample.h |  16 +-
+ .../auxiliary/gallivm/lp_bld_sample_soa.c     | 156 ++++++++++--------
+ .../drivers/llvmpipe/ci/traces-llvmpipe.yml   |   6 +-
+ 6 files changed, 193 insertions(+), 116 deletions(-)
+
+diff --git a/src/gallium/auxiliary/gallivm/lp_bld_arit.c b/src/gallium/auxiliary/gallivm/lp_bld_arit.c
+index d0264e42c9f..ef7bf0f72cd 100644
+--- a/src/gallium/auxiliary/gallivm/lp_bld_arit.c
++++ b/src/gallium/auxiliary/gallivm/lp_bld_arit.c
+@@ -1668,6 +1668,26 @@ lp_build_clamp(struct lp_build_context *bld,
+ }
+ 
+ 
++/**
++ * Generate clamp(a, min, max)
++ * A NaN will get converted to min.
++ */
++LLVMValueRef
++lp_build_clamp_nanmin(struct lp_build_context *bld,
++                      LLVMValueRef a,
++                      LLVMValueRef min,
++                      LLVMValueRef max)
++{
++   assert(lp_check_value(bld->type, a));
++   assert(lp_check_value(bld->type, min));
++   assert(lp_check_value(bld->type, max));
++
++   a = lp_build_max_ext(bld, a, min, GALLIVM_NAN_RETURN_OTHER_SECOND_NONNAN);
++   a = lp_build_min(bld, a, max);
++   return a;
++}
++
++
+ /**
+  * Generate clamp(a, 0, 1)
+  * A NaN will get converted to zero.
+diff --git a/src/gallium/auxiliary/gallivm/lp_bld_arit.h b/src/gallium/auxiliary/gallivm/lp_bld_arit.h
+index b335916027f..f64dfb3dd6f 100644
+--- a/src/gallium/auxiliary/gallivm/lp_bld_arit.h
++++ b/src/gallium/auxiliary/gallivm/lp_bld_arit.h
+@@ -216,6 +216,12 @@ lp_build_clamp(struct lp_build_context *bld,
+                LLVMValueRef min,
+                LLVMValueRef max);
+ 
++LLVMValueRef
++lp_build_clamp_nanmin(struct lp_build_context *bld,
++                      LLVMValueRef a,
++                      LLVMValueRef min,
++                      LLVMValueRef max);
++
+ LLVMValueRef
+ lp_build_clamp_zero_one_nanzero(struct lp_build_context *bld,
+                                 LLVMValueRef a);
+diff --git a/src/gallium/auxiliary/gallivm/lp_bld_sample.c b/src/gallium/auxiliary/gallivm/lp_bld_sample.c
+index 4fafb5d3be6..c602f7dc9e0 100644
+--- a/src/gallium/auxiliary/gallivm/lp_bld_sample.c
++++ b/src/gallium/auxiliary/gallivm/lp_bld_sample.c
+@@ -263,19 +263,23 @@ lp_sampler_static_sampler_state(struct lp_static_sampler_state *state,
+ }
+ 
+ 
+-/* build aniso pmin value */
++/* build aniso rho value */
+ static LLVMValueRef
+-lp_build_pmin(struct lp_build_sample_context *bld,
+-              LLVMValueRef first_level,
+-              LLVMValueRef s,
+-              LLVMValueRef t)
++lp_build_rho_aniso(struct lp_build_sample_context *bld,
++                   LLVMValueRef first_level,
++                   LLVMValueRef s,
++                   LLVMValueRef t,
++                   struct lp_aniso_values *aniso_values)
+ {
+    struct gallivm_state *gallivm = bld->gallivm;
+    LLVMBuilderRef builder = bld->gallivm->builder;
+    struct lp_build_context *coord_bld = &bld->coord_bld;
++   struct lp_build_context *int_coord_bld = &bld->int_coord_bld;
+    struct lp_build_context *int_size_bld = &bld->int_size_in_bld;
+    struct lp_build_context *float_size_bld = &bld->float_size_in_bld;
+-   struct lp_build_context *pmin_bld = &bld->lodf_bld;
++   struct lp_build_context *rho_bld = &bld->lodf_bld;
++   struct lp_build_context *rate_bld = &bld->aniso_rate_bld;
++   struct lp_build_context *direction_bld = &bld->aniso_direction_bld;
+    LLVMTypeRef i32t = LLVMInt32TypeInContext(bld->gallivm->context);
+    LLVMValueRef index0 = LLVMConstInt(i32t, 0, 0);
+    LLVMValueRef index1 = LLVMConstInt(i32t, 1, 0);
+@@ -283,7 +287,7 @@ lp_build_pmin(struct lp_build_sample_context *bld,
+    LLVMValueRef int_size, float_size;
+    const unsigned length = coord_bld->type.length;
+    const unsigned num_quads = length / 4;
+-   const bool pmin_per_quad = pmin_bld->type.length != length;
++   const bool rho_per_quad = rho_bld->type.length != length;
+ 
+    int_size = lp_build_minify(int_size_bld, bld->int_size, first_level, true);
+    float_size = lp_build_int_to_float(float_size_bld, int_size);
+@@ -311,7 +315,7 @@ lp_build_pmin(struct lp_build_sample_context *bld,
+    ddx_ddys = lp_build_swizzle_aos(coord_bld, ddx_ddy, swizzle01);
+    ddx_ddyt = lp_build_swizzle_aos(coord_bld, ddx_ddy, swizzle23);
+ 
+-   LLVMValueRef px2_py2 = lp_build_add(coord_bld, ddx_ddys, ddx_ddyt);
++   LLVMValueRef rho_x2_rho_y2 = lp_build_add(coord_bld, ddx_ddys, ddx_ddyt);
+ 
+    static const unsigned char swizzle0[] = { /* no-op swizzle */
+      0, LP_BLD_SWIZZLE_DONTCARE,
+@@ -321,30 +325,37 @@ lp_build_pmin(struct lp_build_sample_context *bld,
+      1, LP_BLD_SWIZZLE_DONTCARE,
+      LP_BLD_SWIZZLE_DONTCARE, LP_BLD_SWIZZLE_DONTCARE
+    };
+-   LLVMValueRef px2 = lp_build_swizzle_aos(coord_bld, px2_py2, swizzle0);
+-   LLVMValueRef py2 = lp_build_swizzle_aos(coord_bld, px2_py2, swizzle1);
+-
+-   LLVMValueRef pmax2 = lp_build_max(coord_bld, px2, py2);
+-   LLVMValueRef pmin2 = lp_build_min(coord_bld, px2, py2);
++   LLVMValueRef rho_x2 = lp_build_swizzle_aos(coord_bld, rho_x2_rho_y2, swizzle0);
++   LLVMValueRef rho_y2 = lp_build_swizzle_aos(coord_bld, rho_x2_rho_y2, swizzle1);
+ 
+-   LLVMValueRef temp = lp_build_mul(
+-      coord_bld, pmin2, lp_build_const_vec(gallivm, coord_bld->type, bld->static_sampler_state->aniso *
+-                                           bld->static_sampler_state->aniso));
++   LLVMValueRef rho_max2 = lp_build_max(coord_bld, rho_x2, rho_y2);
++   LLVMValueRef rho_min2 = lp_build_min(coord_bld, rho_x2, rho_y2);
+ 
+-   LLVMValueRef comp = lp_build_compare(gallivm, coord_bld->type, PIPE_FUNC_GREATER,
+-                                        pmax2, temp);
++   LLVMValueRef min_aniso2 = coord_bld->one;
++   LLVMValueRef max_aniso2 = lp_build_const_vec(gallivm, coord_bld->type, bld->static_sampler_state->aniso * bld->static_sampler_state->aniso);
++   LLVMValueRef eta2 = lp_build_clamp_nanmin(coord_bld, lp_build_div(coord_bld, rho_max2, rho_min2), min_aniso2, max_aniso2);
++   LLVMValueRef N = lp_build_iceil(coord_bld, lp_build_sqrt(coord_bld, eta2));
+ 
+-   LLVMValueRef pmin2_alt = lp_build_div(coord_bld, pmax2,
+-      lp_build_const_vec(gallivm, coord_bld->type, bld->static_sampler_state->aniso));
++   LLVMValueRef direction = lp_build_cmp(coord_bld, PIPE_FUNC_GREATER, rho_x2, rho_y2);
+ 
+-   pmin2 = lp_build_select(coord_bld, comp, pmin2_alt, pmin2);
++   /* If eta2 was clamped this will increase the rho_min2 value,
++    * increasing the LOD value (using a lower resolution mip) so
++    * that the sampling loop does not skip pixels.
++    */
++   rho_min2 = lp_build_div(coord_bld, rho_max2, eta2);
++
++   if (rho_per_quad) {
++      aniso_values->rate = lp_build_pack_aos_scalars(bld->gallivm, int_coord_bld->type,
++         rate_bld->type, N, 0);
++      aniso_values->direction = lp_build_pack_aos_scalars(bld->gallivm, int_coord_bld->type,
++         direction_bld->type, direction, 0);
++      return lp_build_pack_aos_scalars(bld->gallivm, coord_bld->type,
++                                        rho_bld->type, rho_min2, 0);
++   }
+ 
+-   if (pmin_per_quad)
+-      pmin2 = lp_build_pack_aos_scalars(bld->gallivm, coord_bld->type,
+-                                        pmin_bld->type, pmin2, 0);
+-   else
+-      pmin2 = lp_build_swizzle_scalar_aos(pmin_bld, pmin2, 0, 4);
+-   return pmin2;
++   aniso_values->rate = lp_build_swizzle_scalar_aos(rate_bld, N, 0, 4);
++   aniso_values->direction = lp_build_swizzle_scalar_aos(direction_bld, direction, 0, 4);
++   return lp_build_swizzle_scalar_aos(rho_bld, rho_min2, 0, 4);
+ }
+ 
+ 
+@@ -801,6 +812,7 @@ lp_build_ilog2_sqrt(struct lp_build_context *bld,
+  * \param out_lod_ipart  integer part of lod
+  * \param out_lod_fpart  float part of lod (never larger than 1 but may be negative)
+  * \param out_lod_positive  (mask) if lod is positive (i.e. texture is minified)
++ * \param out_aniso_values  aniso sampling values
+  *
+  * The resulting lod can be scalar per quad or be per element.
+  */
+@@ -819,7 +831,8 @@ lp_build_lod_selector(struct lp_build_sample_context *bld,
+                       LLVMValueRef *out_lod,
+                       LLVMValueRef *out_lod_ipart,
+                       LLVMValueRef *out_lod_fpart,
+-                      LLVMValueRef *out_lod_positive)
++                      LLVMValueRef *out_lod_positive,
++                      struct lp_aniso_values *out_aniso_values)
+ 
+ {
+    LLVMBuilderRef builder = bld->gallivm->builder;
+@@ -830,6 +843,8 @@ lp_build_lod_selector(struct lp_build_sample_context *bld,
+    *out_lod_ipart = bld->lodi_bld.zero;
+    *out_lod_positive = bld->lodi_bld.zero;
+    *out_lod_fpart = lodf_bld->zero;
++   out_aniso_values->rate = bld->aniso_rate_bld.one;
++   out_aniso_values->direction = bld->aniso_direction_bld.zero;
+ 
+    /*
+     * For determining min/mag, we follow GL 4.1 spec, 3.9.12 Texture
+@@ -849,6 +864,17 @@ lp_build_lod_selector(struct lp_build_sample_context *bld,
+     * have no clue about the (undocumented) wishes of d3d9/d3d10 here!
+     */
+ 
++   LLVMValueRef rho = NULL;
++   bool rho_squared;
++
++   /* When anisotropic filtering is enabled, we always compute rho,
++    * since it's used to derive the anisotropic sampling rate.
++    */
++   if (bld->static_sampler_state->aniso) {
++      rho = lp_build_rho_aniso(bld, first_level, s, t, out_aniso_values);
++      rho_squared = true;
++   }
++
+    if (bld->static_sampler_state->min_max_lod_equal && !is_lodq) {
+       /* User is forcing sampling from a particular mipmap level.
+        * This is hit during mipmap generation.
+@@ -860,21 +886,16 @@ lp_build_lod_selector(struct lp_build_sample_context *bld,
+       lod = lp_build_broadcast_scalar(lodf_bld, min_lod);
+    } else {
+       if (explicit_lod) {
+-         if (bld->num_lods != bld->coord_type.length)
++         if (bld->num_lods != bld->coord_type.length) {
+             lod = lp_build_pack_aos_scalars(bld->gallivm, bld->coord_bld.type,
+                                             lodf_bld->type, explicit_lod, 0);
+-         else
++         } else {
+             lod = explicit_lod;
++         }
+       } else {
+-         LLVMValueRef rho;
+-         bool rho_squared = bld->no_rho_approx && (bld->dims > 1);
+-
+-         if (bld->static_sampler_state->aniso &&
+-             !explicit_lod) {
+-            rho = lp_build_pmin(bld, first_level, s, t);
+-            rho_squared = true;
+-         } else {
++         if (!rho) {
+             rho = lp_build_rho(bld, first_level, s, t, r, derivs);
++            rho_squared = bld->no_rho_approx && (bld->dims > 1);
+          }
+ 
+          /*
+@@ -882,7 +903,6 @@ lp_build_lod_selector(struct lp_build_sample_context *bld,
+           */
+ 
+          if (!lod_bias && !is_lodq &&
+-             !bld->static_sampler_state->aniso &&
+              !bld->static_sampler_state->lod_bias_non_zero &&
+              !bld->static_sampler_state->apply_max_lod &&
+              !bld->static_sampler_state->apply_min_lod) {
+@@ -908,8 +928,7 @@ lp_build_lod_selector(struct lp_build_sample_context *bld,
+                return;
+             }
+             if (mip_filter == PIPE_TEX_MIPFILTER_LINEAR &&
+-                !bld->no_brilinear && !rho_squared &&
+-                !bld->static_sampler_state->aniso) {
++                !bld->no_brilinear && !rho_squared) {
+                /*
+                 * This can't work if rho is squared. Not sure if it could be
+                 * fixed while keeping it worthwile, could also do sqrt here
+@@ -990,9 +1009,7 @@ lp_build_lod_selector(struct lp_build_sample_context *bld,
+    *out_lod_positive = lp_build_cmp(lodf_bld, PIPE_FUNC_GREATER,
+                                     lod, lodf_bld->zero);
+ 
+-   if (bld->static_sampler_state->aniso) {
+-      *out_lod_ipart = lp_build_itrunc(lodf_bld, lod);
+-   } else if (mip_filter == PIPE_TEX_MIPFILTER_LINEAR) {
++   if (mip_filter == PIPE_TEX_MIPFILTER_LINEAR) {
+       if (!bld->no_brilinear) {
+          lp_build_brilinear_lod(lodf_bld, lod, BRILINEAR_FACTOR,
+                                 out_lod_ipart, out_lod_fpart);
+diff --git a/src/gallium/auxiliary/gallivm/lp_bld_sample.h b/src/gallium/auxiliary/gallivm/lp_bld_sample.h
+index f6612e03a0e..87fb32bf1c3 100644
+--- a/src/gallium/auxiliary/gallivm/lp_bld_sample.h
++++ b/src/gallium/auxiliary/gallivm/lp_bld_sample.h
+@@ -483,6 +483,14 @@ struct lp_build_sample_context
+    struct lp_type lodi_type;
+    struct lp_build_context lodi_bld;
+ 
++   /** Aniso filtering direction type */
++   struct lp_type aniso_rate_type;
++   struct lp_build_context aniso_rate_bld;
++
++   /** Aniso filtering rate type */
++   struct lp_type aniso_direction_type;
++   struct lp_build_context aniso_direction_bld;
++
+    /* Common dynamic state values */
+    LLVMTypeRef row_stride_type;
+    LLVMValueRef row_stride_array;
+@@ -531,6 +539,11 @@ struct lp_build_img_op_array_switch {
+    LLVMValueRef phi[4];
+ };
+ 
++struct lp_aniso_values {
++   LLVMValueRef rate;
++   LLVMValueRef direction; /* true: X, false: Y */
++};
++
+ 
+ /**
+  * We only support a few wrap modes in lp_build_sample_wrap_linear_int() at
+@@ -642,7 +655,8 @@ lp_build_lod_selector(struct lp_build_sample_context *bld,
+                       LLVMValueRef *out_lod,
+                       LLVMValueRef *out_lod_ipart,
+                       LLVMValueRef *out_lod_fpart,
+-                      LLVMValueRef *out_lod_positive);
++                      LLVMValueRef *out_lod_positive,
++                      struct lp_aniso_values *out_aniso);
+ 
+ void
+ lp_build_nearest_mip_level(struct lp_build_sample_context *bld,
+diff --git a/src/gallium/auxiliary/gallivm/lp_bld_sample_soa.c b/src/gallium/auxiliary/gallivm/lp_bld_sample_soa.c
+index 89e6388f0c6..f23c89fe21e 100644
+--- a/src/gallium/auxiliary/gallivm/lp_bld_sample_soa.c
++++ b/src/gallium/auxiliary/gallivm/lp_bld_sample_soa.c
+@@ -2182,9 +2182,6 @@ lp_build_sample_ms_offset(struct lp_build_context *int_coord_bld,
+ }
+ 
+ 
+-#define WEIGHT_LUT_SIZE 1024
+-
+-
+ static void
+ lp_build_sample_aniso(struct lp_build_sample_context *bld,
+                       const LLVMValueRef *coords,
+@@ -2192,19 +2189,21 @@ lp_build_sample_aniso(struct lp_build_sample_context *bld,
+                       LLVMValueRef ilevel0,
+                       LLVMValueRef ilevel1,
+                       LLVMValueRef lod_fpart,
++                      struct lp_aniso_values *aniso_values,
+                       LLVMValueRef *colors_out)
+ {
++   assert(aniso_values);
++
+    struct gallivm_state *gallivm = bld->gallivm;
+    LLVMBuilderRef builder = gallivm->builder;
+    struct lp_build_context *coord_bld = &bld->coord_bld;
+    struct lp_build_context *int_coord_bld = &bld->int_coord_bld;
+-   struct lp_build_context uint_coord_bld;
++   struct lp_build_context *rate_bld = &bld->aniso_rate_bld;
++   struct lp_build_context *direction_bld = &bld->aniso_direction_bld;
+ 
+    LLVMValueRef size0, row_stride0_vec, img_stride0_vec;
+    LLVMValueRef data_ptr0, mipoff0 = NULL;
+ 
+-   lp_build_context_init(&uint_coord_bld, gallivm, lp_uint_type(int_coord_bld->type));
+-
+    lp_build_mipmap_level_sizes(bld, ilevel0,
+                                &size0,
+                                &row_stride0_vec, &img_stride0_vec);
+@@ -2216,40 +2215,18 @@ lp_build_sample_aniso(struct lp_build_sample_context *bld,
+       mipoff0 = lp_build_get_mip_offsets(bld, ilevel0);
+    }
+ 
+-   LLVMValueRef float_size_lvl = lp_build_int_to_float(&bld->float_size_bld, size0);
+-
+-   /* extract width and height into vectors for use later */
+-   static const unsigned char swizzle15[] = { /* no-op swizzle */
+-      1, 1, 1, 1, 5, 5, 5, 5
+-   };
+-   static const unsigned char swizzle04[] = { /* no-op swizzle */
+-      0, 0, 0, 0, 4, 4, 4, 4
+-   };
+-   LLVMValueRef width_dim, height_dim;
+-
+-   width_dim = lp_build_swizzle_aos_n(gallivm, float_size_lvl, swizzle04,
+-                                      bld->float_size_bld.type.length,
+-                                      bld->coord_bld.type.length);
+-   height_dim = lp_build_swizzle_aos_n(gallivm, float_size_lvl, swizzle15,
+-                                       bld->float_size_bld.type.length,
+-                                       bld->coord_bld.type.length);
+-
+-   /* Gradient of the u coordinate in screen space. */
+-   LLVMValueRef dudx = lp_build_ddx(coord_bld, coords[0]);
+-   LLVMValueRef dudy = lp_build_ddy(coord_bld, coords[0]);
+-
+-   /* Gradient of the v coordinate in screen space. */
+-   LLVMValueRef dvdx = lp_build_ddx(coord_bld, coords[1]);
+-   LLVMValueRef dvdy = lp_build_ddy(coord_bld, coords[1]);
+-
+-   LLVMValueRef rho_x = lp_build_mul(coord_bld, lp_build_max(coord_bld, lp_build_abs(coord_bld, dudx), lp_build_abs(coord_bld, dvdx)), width_dim);
+-   LLVMValueRef rho_y = lp_build_mul(coord_bld, lp_build_max(coord_bld, lp_build_abs(coord_bld, dudy), lp_build_abs(coord_bld, dvdy)), height_dim);
++   LLVMValueRef N = aniso_values->rate;
++   if (rate_bld->type.length != int_coord_bld->type.length) {
++      N = lp_build_unpack_broadcast_aos_scalars(bld->gallivm,
++         rate_bld->type, int_coord_bld->type, N);
++   }
+ 
+-   /* Number of samples used for averaging. */
+-   LLVMValueRef N = lp_build_iceil(coord_bld, lp_build_max(coord_bld, rho_x, rho_y));
++   LLVMValueRef sample_along_x = aniso_values->direction;
++   if (direction_bld->type.length != int_coord_bld->type.length) {
++      sample_along_x = lp_build_unpack_broadcast_aos_scalars(bld->gallivm,
++         direction_bld->type, int_coord_bld->type, sample_along_x);
++   }
+ 
+-   /* Use uint min so in case of NaNs/overflows loop iterations are clamped to max aniso */
+-   N = lp_build_min(&uint_coord_bld, N, lp_build_const_int_vec(gallivm, int_coord_bld->type, bld->static_sampler_state->aniso));
+    LLVMValueRef wave_max_N = NULL;
+    for (uint32_t i = 0; i < coord_bld->type.length; i++) {
+       LLVMValueRef invocation_N = LLVMBuildExtractElement(builder, N, lp_build_const_int32(gallivm, i), "");
+@@ -2259,9 +2236,16 @@ lp_build_sample_aniso(struct lp_build_sample_context *bld,
+          wave_max_N = invocation_N;
+    }
+ 
+-   LLVMValueRef sample_along_x_axis = lp_build_cmp(coord_bld, PIPE_FUNC_GREATER, rho_x, rho_y);
+-   LLVMValueRef dudk = lp_build_select(coord_bld, sample_along_x_axis, dudx, dudy);
+-   LLVMValueRef dvdk = lp_build_select(coord_bld, sample_along_x_axis, dvdx, dvdy);
++   /* Gradient of the u coordinate in screen space. */
++   LLVMValueRef dudx = lp_build_ddx(coord_bld, coords[0]);
++   LLVMValueRef dudy = lp_build_ddy(coord_bld, coords[0]);
++
++   /* Gradient of the v coordinate in screen space. */
++   LLVMValueRef dvdx = lp_build_ddx(coord_bld, coords[1]);
++   LLVMValueRef dvdy = lp_build_ddy(coord_bld, coords[1]);
++
++   LLVMValueRef dudk = lp_build_select(coord_bld, sample_along_x, dudx, dudy);
++   LLVMValueRef dvdk = lp_build_select(coord_bld, sample_along_x, dvdx, dvdy);
+ 
+    LLVMValueRef accumulator[4] = {
+       lp_build_alloca(gallivm, bld->texel_bld.vec_type, "r"),
+@@ -2270,11 +2254,28 @@ lp_build_sample_aniso(struct lp_build_sample_context *bld,
+       lp_build_alloca(gallivm, bld->texel_bld.vec_type, "a"),
+    };
+ 
++   /*
++    * We use the suggested anisotropic filtering algorithm from the Vulkan spec:
++    * https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#textures-texel-anisotropic-filtering
++    * The coordinate offset expression is the same in all cases: -1/2 + i / (N + 1)
++    * We can rewrite this expression as: (-N - 1) / (2N + 2) + 2i / (2N + 2) =
++    *     (-N - 1 + 2i) / (2N + 2) = (-0.5N - 0.5 + i) / (N + 1)
++    * Instead of 1-based indexing with i, we use 0-based k: i = k + 1
++    * Subtituting k, we get our final expression: (-0.5N + 0.5 + k) / (N + 1)
++    * We split this into base_k = -0.5N + 0.5 and rcp_N_plus_one = 1 / (N + 1)
++    * In the loop we obtain our offset by doing (k + base_k) * rcp_N_plus_one
++    */
+    LLVMValueRef float_N = lp_build_int_to_float(coord_bld, N);
+    LLVMValueRef rcp_N = lp_build_rcp(coord_bld, float_N);
++   LLVMValueRef rcp_N_plus_one = lp_build_rcp(coord_bld, lp_build_add(coord_bld, float_N, coord_bld->one));
+    LLVMValueRef base_k = LLVMBuildFMul(builder, float_N, lp_build_const_vec(gallivm, coord_bld->type, -0.5), "");
+    base_k = lp_build_add(coord_bld, base_k, lp_build_const_vec(gallivm, coord_bld->type, 0.5));
+ 
++   LLVMValueRef tmp_color[4];
++   for (int i = 0; i < ARRAY_SIZE(tmp_color); i++) {
++      tmp_color[i] = lp_build_alloca(gallivm, bld->texel_bld.vec_type, "");
++   }
++
+    struct lp_build_for_loop_state loop_state;
+    lp_build_for_loop_begin(&loop_state, gallivm, lp_build_const_int32(gallivm, 0),
+                            LLVMIntULT, wave_max_N, lp_build_const_int32(gallivm, 1));
+@@ -2284,7 +2285,7 @@ lp_build_sample_aniso(struct lp_build_sample_context *bld,
+ 
+       LLVMValueRef float_k = lp_build_int_to_float(coord_bld, k);
+       float_k = lp_build_add(coord_bld, float_k, base_k);
+-      float_k = lp_build_mul(coord_bld, float_k, rcp_N);
++      float_k = lp_build_mul(coord_bld, float_k, rcp_N_plus_one);
+ 
+       LLVMValueRef u_offset = lp_build_mul(coord_bld, float_k, dudk);
+       LLVMValueRef v_offset = lp_build_mul(coord_bld, float_k, dvdk);
+@@ -2296,23 +2297,33 @@ lp_build_sample_aniso(struct lp_build_sample_context *bld,
+       for (uint32_t i = 2; i < ARRAY_SIZE(sample_coords); i++)
+          sample_coords[i] = coords[i];
+ 
+-
+       if (bld->static_texture_state->target == PIPE_TEXTURE_CUBE ||
+           bld->static_texture_state->target == PIPE_TEXTURE_CUBE_ARRAY) {
+          /* Make sure the coordinates stay in bounds for PIPE_TEXTURE_CUBE loads since
+           * lp_build_sample_image_linear uses less clamping for them.
+           */
+-         sample_coords[0] = lp_build_max(coord_bld, sample_coords[0], bld->coord_bld.zero);
+-         sample_coords[0] = lp_build_min(coord_bld, sample_coords[0], bld->coord_bld.one);
+-         sample_coords[1] = lp_build_max(coord_bld, sample_coords[1], bld->coord_bld.zero);
+-         sample_coords[1] = lp_build_min(coord_bld, sample_coords[1], bld->coord_bld.one);
++         sample_coords[0] = lp_build_clamp(coord_bld, sample_coords[0], bld->coord_bld.zero, bld->coord_bld.one);
++         sample_coords[1] = lp_build_clamp(coord_bld, sample_coords[1], bld->coord_bld.zero, bld->coord_bld.one);
+       }
+ 
++      /* Anisotropic filtering is allowed to ignore min and mag filters. We always use linear.
++       * Mip filtering has a big quality impact though, so we use that if enabled.
++       */
+       LLVMValueRef sample_color[4];
+-      lp_build_sample_image_linear(bld, false, size0, NULL,
+-                                   row_stride0_vec, img_stride0_vec,
+-                                   data_ptr0, mipoff0, ilevel0, sample_coords, offsets,
+-                                   sample_color);
++      if (bld->static_sampler_state->min_mip_filter == PIPE_TEX_MIPFILTER_LINEAR) {
++         lp_build_sample_mipmap(bld, PIPE_TEX_FILTER_LINEAR, PIPE_TEX_MIPFILTER_LINEAR,
++                                false, sample_coords, offsets,
++                                ilevel0, ilevel1, lod_fpart,
++                                tmp_color);
++         for (int i = 0; i < ARRAY_SIZE(sample_color); i++) {
++            sample_color[i] = LLVMBuildLoad2(builder, bld->texel_bld.vec_type, tmp_color[i], "");
++         }
++      } else {
++         lp_build_sample_image_linear(bld, false, size0, NULL,
++                                      row_stride0_vec, img_stride0_vec,
++                                      data_ptr0, mipoff0, ilevel0, sample_coords, offsets,
++                                      sample_color);
++      }
+ 
+       LLVMValueRef oob = lp_build_cmp(int_coord_bld, PIPE_FUNC_GEQUAL, k, N);
+ 
+@@ -2347,7 +2358,8 @@ lp_build_sample_common(struct lp_build_sample_context *bld,
+                        LLVMValueRef *lod,
+                        LLVMValueRef *lod_fpart,
+                        LLVMValueRef *ilevel0,
+-                       LLVMValueRef *ilevel1)
++                       LLVMValueRef *ilevel1,
++                       struct lp_aniso_values *aniso_values)
+ {
+    const unsigned mip_filter = bld->static_sampler_state->min_mip_filter;
+    const unsigned min_filter = bld->static_sampler_state->min_img_filter;
+@@ -2431,10 +2443,11 @@ lp_build_sample_common(struct lp_build_sample_context *bld,
+    /*
+     * Compute the level of detail (float).
+     */
+-   if (min_filter != mag_filter ||
+-       mip_filter != PIPE_TEX_MIPFILTER_NONE || is_lodq) {
+-      /* Need to compute lod either to choose mipmap levels or to
+-       * distinguish between minification/magnification with one mipmap level.
++   if (min_filter != mag_filter || mip_filter != PIPE_TEX_MIPFILTER_NONE ||
++         is_lodq || aniso) {
++      /* Need to compute lod either to choose mipmap levels, or to
++       * distinguish between minification/magnification with one mipmap level,
++       * or to compute anisotropic sampling rate.
+        */
+       LLVMValueRef first_level_vec =
+          lp_build_broadcast_scalar(&bld->int_size_in_bld, first_level);
+@@ -2443,7 +2456,8 @@ lp_build_sample_common(struct lp_build_sample_context *bld,
+                             coords[0], coords[1], coords[2],
+                             derivs, lod_bias, explicit_lod,
+                             mip_filter, lod,
+-                            &lod_ipart, lod_fpart, lod_pos_or_zero);
++                            &lod_ipart, lod_fpart, lod_pos_or_zero,
++                            aniso_values);
+       if (is_lodq) {
+          last_level = lp_build_sub(&bld->int_bld, last_level, first_level);
+          last_level = lp_build_int_to_float(&bld->float_bld, last_level);
+@@ -2482,13 +2496,6 @@ lp_build_sample_common(struct lp_build_sample_context *bld,
+     * Compute integer mipmap level(s) to fetch texels from: ilevel0, ilevel1
+     */
+ 
+-   if (aniso) {
+-      lp_build_nearest_mip_level(bld,
+-                                 first_level, last_level,
+-                                 lod_ipart, ilevel0, NULL);
+-      return;
+-   }
+-
+    switch (mip_filter) {
+    default:
+       unreachable("Bad mip_filter value in lp_build_sample_soa()");
+@@ -2755,6 +2762,7 @@ lp_build_sample_general(struct lp_build_sample_context *bld,
+                         LLVMValueRef lod_fpart,
+                         LLVMValueRef ilevel0,
+                         LLVMValueRef ilevel1,
++                        struct lp_aniso_values *aniso_values,
+                         LLVMValueRef *colors_out)
+ {
+    LLVMBuilderRef builder = bld->gallivm->builder;
+@@ -2792,7 +2800,8 @@ lp_build_sample_general(struct lp_build_sample_context *bld,
+ 
+    if (sampler_state->aniso) {
+       lp_build_sample_aniso(bld, coords, offsets, ilevel0,
+-                            ilevel1, lod_fpart, texels);
++                            ilevel1, lod_fpart, aniso_values,
++                            texels);
+    } else if (min_filter == mag_filter) {
+       /* no need to distinguish between minification and magnification */
+       lp_build_sample_mipmap(bld, min_filter, mip_filter,
+@@ -3379,6 +3388,9 @@ lp_build_sample_soa_code(struct gallivm_state *gallivm,
+    bld.leveli_type = lp_int_type(bld.levelf_type);
+    bld.float_size_type = bld.float_size_in_type;
+ 
++   bld.aniso_rate_type = bld.lodi_type;
++   bld.aniso_direction_type = bld.lodi_type;
++
+    /* Note: size vectors may not be native. They contain minified w/h/d/_
+     * values, with per-element lod that is w0/h0/d0/_/w1/h1/d1_/... so up to
+     * 8x4f32
+@@ -3404,6 +3416,8 @@ lp_build_sample_soa_code(struct gallivm_state *gallivm,
+    lp_build_context_init(&bld.leveli_bld, gallivm, bld.leveli_type);
+    lp_build_context_init(&bld.lodf_bld, gallivm, bld.lodf_type);
+    lp_build_context_init(&bld.lodi_bld, gallivm, bld.lodi_type);
++   lp_build_context_init(&bld.aniso_rate_bld, gallivm, bld.aniso_rate_type);
++   lp_build_context_init(&bld.aniso_direction_bld, gallivm, bld.aniso_direction_type);
+ 
+    /* Get the dynamic state */
+    LLVMValueRef tex_width = dynamic_state->width(gallivm, resources_type,
+@@ -3542,6 +3556,7 @@ lp_build_sample_soa_code(struct gallivm_state *gallivm,
+    } else {
+       LLVMValueRef lod_fpart = NULL, lod_positive = NULL;
+       LLVMValueRef ilevel0 = NULL, ilevel1 = NULL, lod = NULL;
++      struct lp_aniso_values aniso_values = {};
+       bool use_aos = util_format_fits_8unorm(bld.format_desc) &&
+                 op_is_tex &&
+                 /* not sure this is strictly needed or simply impossible */
+@@ -3593,7 +3608,7 @@ lp_build_sample_soa_code(struct gallivm_state *gallivm,
+       lp_build_sample_common(&bld, op_is_lodq, texture_index, sampler_index,
+                              newcoords, derivs, lod_bias, explicit_lod,
+                              &lod_positive, &lod, &lod_fpart,
+-                             &ilevel0, &ilevel1);
++                             &ilevel0, &ilevel1, &aniso_values);
+ 
+       if (op_is_lodq) {
+          texel_out[0] = lod_fpart;
+@@ -3632,7 +3647,7 @@ lp_build_sample_soa_code(struct gallivm_state *gallivm,
+                                     op_type == LP_SAMPLER_OP_GATHER,
+                                     newcoords, offsets,
+                                     lod_positive, lod_fpart,
+-                                    ilevel0, ilevel1,
++                                    ilevel0, ilevel1, &aniso_values,
+                                     texel_out);
+             if (bld.residency)
+                texel_out[4] = bld.resident;
+@@ -3722,6 +3737,9 @@ lp_build_sample_soa_code(struct gallivm_state *gallivm,
+          }
+          bld4.int_size_type = lp_int_type(bld4.float_size_type);
+ 
++         bld4.aniso_rate_type = bld4.lodi_type;
++         bld4.aniso_direction_type = bld4.lodi_type;
++
+          lp_build_context_init(&bld4.float_bld, gallivm, bld4.float_type);
+          lp_build_context_init(&bld4.float_vec_bld, gallivm, type4);
+          lp_build_context_init(&bld4.int_bld, gallivm, bld4.int_type);
+@@ -3736,6 +3754,8 @@ lp_build_sample_soa_code(struct gallivm_state *gallivm,
+          lp_build_context_init(&bld4.leveli_bld, gallivm, bld4.leveli_type);
+          lp_build_context_init(&bld4.lodf_bld, gallivm, bld4.lodf_type);
+          lp_build_context_init(&bld4.lodi_bld, gallivm, bld4.lodi_type);
++         lp_build_context_init(&bld4.aniso_rate_bld, gallivm, bld4.aniso_rate_type);
++         lp_build_context_init(&bld4.aniso_direction_bld, gallivm, bld4.aniso_direction_type);
+ 
+          for (unsigned i = 0; i < num_quads; i++) {
+             LLVMValueRef s4, t4, r4;
+@@ -3785,7 +3805,7 @@ lp_build_sample_soa_code(struct gallivm_state *gallivm,
+                                        op_type == LP_SAMPLER_OP_GATHER,
+                                        newcoords4, offsets4,
+                                        lod_positive4, lod_fpart4,
+-                                       ilevel04, ilevel14,
++                                       ilevel04, ilevel14, &aniso_values,
+                                        texelout4);
+             }
+             for (unsigned j = 0; j < 4; j++) {
+-- 
+2.34.1
+

--- a/meta-flex-staging/recipes-graphics/mesa/mesa.inc
+++ b/meta-flex-staging/recipes-graphics/mesa/mesa.inc
@@ -22,6 +22,15 @@ SRC_URI = "https://mesa.freedesktop.org/archive/mesa-${PV}.tar.xz \
            file://0001-meson-misdetects-64bit-atomics-on-mips-clang.patch \
            file://0001-util-add-c-guards-to-u_mm.h.patch \
            file://0002-gfxstream-nuke-android-base-SubAllocator.patch \
+           file://0001-llvmpipe-Disable-anisotropic-filtering-for-explicit-.patch \
+           file://0002-llvmpipe-Use-a-simpler-and-faster-AF-implementation.patch \
+           file://0003-llvmpipe-Remove-unused-AF-code.patch \
+           file://0004-llvmpipe-Move-max_anisotropy-to-static-sampler-state.patch \
+           file://0005-llvmpipe-disable-anisotropic-filtering-for-non-2D-te.patch \
+           file://0006-llvmpipe-Fix-half-pixel-sample-offset-with-AF.patch \
+           file://0007-llvmpipe-Avoid-a-crash-when-using-5-coords-with-AF.patch \
+           file://0008-llvmpipe-Fix-overflow-issues-calculating-loop-iterat.patch \
+           file://0009-llvmpipe-improve-aniso-filtering.patch \
 "
 
 SRC_URI[sha256sum] = "e641ae27191d387599219694560d221b7feaa91c900bcec46bf444218ed66025"

--- a/meta-flex-staging/recipes-graphics/mesa/mesa.inc
+++ b/meta-flex-staging/recipes-graphics/mesa/mesa.inc
@@ -20,6 +20,8 @@ PE = "2"
 
 SRC_URI = "https://mesa.freedesktop.org/archive/mesa-${PV}.tar.xz \
            file://0001-meson-misdetects-64bit-atomics-on-mips-clang.patch \
+           file://0001-util-add-c-guards-to-u_mm.h.patch \
+           file://0002-gfxstream-nuke-android-base-SubAllocator.patch \
 "
 
 SRC_URI[sha256sum] = "e641ae27191d387599219694560d221b7feaa91c900bcec46bf444218ed66025"


### PR DESCRIPTION
This fixes two issues.

1. mesa: fix vkmark unrealistic score for CPU-based rendering
    
    Port back the patches to replace aemu library provided allocator
    `android::base::SubAllocator` to `u_mm.h` allocation APIs.
    
    The vkmark reported score for host CPU-based lavapipe gfxstream ICD
    before this change was ~8000 and after this change it is ~1500.
    
    The latter score makes sense as the GPU-based gfxstream ICD gives
    a score of ~3500.
    
    Ref: https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/32015
    
    JIRA-ID: SB-24465

2. mesa: fix vkmark `texture:anisotropy=16` benchmark intermittent hang
    
    When anisotropy is enabled i.e. sampling > 1, benchmark is observed
    to hang. The main patch that fixes this issue is:
    https://gitlab.freedesktop.org/mesa/mesa/-/commit/350a0fe63298d72593c473a0aae83afcd84de9b8
    
    Other patches fixes bugs introduced by this new implementation of
    anisotropy filter. These patches are ported back from mesa-25.
    
    Please note that these patches fixes the anisotropy issue with guest
    CPU-based llvmpipe usage only.
    
    JIRA-ID: SB-24083
