### PR TITLE
remove setup-debian script and Include standard dtb file for prebuild image

### DIFF
--- a/meta-flex-support/recipes-core/meta/archive-release.bb
+++ b/meta-flex-support/recipes-core/meta/archive-release.bb
@@ -100,9 +100,11 @@ SRC_URI:append:qemuall = " file://runqemu.in"
 # Image files to be archived
 IMAGE_BASENAME = "${RELEASE_IMAGE}"
 EXTRA_IMAGES_ARCHIVE_RELEASE ?= ""
+KERNEL_DEVICETREE_ARCHIVE_RELEASE ?= ""
 DEPLOY_IMAGES ?= "\
     ${@' '.join('${IMAGE_LINK_NAME}.%s' % ext for ext in d.getVar('IMAGE_EXTENSIONS').split())} \
     ${EXTRA_IMAGES_ARCHIVE_RELEASE} \
+    ${KERNEL_DEVICETREE_ARCHIVE_RELEASE} \
 "
 DEPLOY_IMAGES:append:qemuall = "${@' ' + d.getVar('KERNEL_IMAGETYPE') if 'wic' not in d.getVar('IMAGE_EXTENSIONS') else ''}"
 DEPLOY_IMAGES[doc] = "List of files from DEPLOY_DIR_IMAGE which will be archived"

--- a/meta-flex-support/recipes-core/meta/archive-release.bb
+++ b/meta-flex-support/recipes-core/meta/archive-release.bb
@@ -84,7 +84,7 @@ def flex_get_remotes(subdir, d):
 
 # Files for the script artifact
 FILESEXTRAPATHS:append = ":${@':'.join('%s/../scripts/release:%s/../scripts' % (l, l) for l in '${BBPATH}'.split(':'))}"
-FLEX_SCRIPTS_FILES = "flex-checkout setup-flex setup-workspace setup-ubuntu setup-rocky setup-debian"
+FLEX_SCRIPTS_FILES = "flex-checkout setup-flex setup-workspace setup-ubuntu setup-rocky"
 SRC_URI += "${@' '.join('file://%s' % s for s in d.getVar('FLEX_SCRIPTS_FILES').split())}"
 # }}}1
 


### PR DESCRIPTION
Removing setup-debian script from installer
[SB-24473](https://jira.alm.mentorg.com/browse/SB-24473)

------------------------
Include KERNEL_DEVICETREE_ARCHIVE_RELEASE variable for dtb file in DEPLOY_IMAGES for archive release.
[SB-24472
](https://jira.alm.mentorg.com/browse/SB-24472)
KERNEL_DEVICETREE defined in, https://github.com/hijaz-siemens/meta-flex-ref-bsps/blob/7f75b5c97da26b7a4c70c2fe3bc2dbd921cbc97c/meta-flex-bsp-innexis-arm64/conf/machine/innexis-arm64.conf#L22