### PR TITLE
setup-ubuntu: removed dependency on libncurses5

### DIFF
--- a/scripts/setup-ubuntu
+++ b/scripts/setup-ubuntu
@@ -36,7 +36,6 @@ $SUDO apt-get -y install $PKGS
 if [ "$(uname -m)" = "x86_64" ]; then
     $SUDO dpkg --add-architecture i386
     $SUDO apt-get -y install libc6-dev-i386
-    $SUDO apt-get -y install libncurses5:i386
 fi
 
 echo "Generating the en_US.UTF-8 locale"


### PR DESCRIPTION
libncurses5 is not required for a Yocto build, so it is removed from setup script for Ubuntu.

JIRA-ID: SB-24478