### PR TITLE
innexis-linux.conf: move alsa feature removal to BSP layer

### DIFF
--- a/meta-flex-distro/conf/distro/innexis-linux.conf
+++ b/meta-flex-distro/conf/distro/innexis-linux.conf
@@ -151,7 +151,6 @@ DISTRO_FEATURES_DEFAULT:remove = "zeroconf"
 DISTRO_FEATURES_DEFAULT:remove = "\
     3g \
     acl \
-    alsa \
     bluetooth \
     nfc \
     nfs \


### PR DESCRIPTION
This feature is needed for ANA BSP virtio sound support, but isn't
supported on Innexis Hybrid BSP at the moment.

Related PR: https://github.com/MentorEmbedded/meta-flex-ref-bsps/pull/305

JIRA-ID: AT1-3558

Signed-off-by: Dave Cook <Dave_Cook@mentor.com>