### PR TITLE
innexis-linux.conf: set FLEX_EXTERNAL_ARTIFACTS path under BUILDDIR

### DIFF
--- a/meta-flex-distro/conf/distro/innexis-linux.conf
+++ b/meta-flex-distro/conf/distro/innexis-linux.conf
@@ -313,7 +313,7 @@ FORKED_REPOS ?= ""
 PUBLIC_REPOS ?= "meta-sokol-flex ${FORKED_REPOS}"
 
 # Define a location for placing external artifacts to be used by the build
-FLEX_EXTERNAL_ARTIFACTS ?= "${TOPDIR}/flex-external-artifacts"
+FLEX_EXTERNAL_ARTIFACTS ?= "${BUILDDIR}/flex-external-artifacts"
 ## }}}1
 ## Includes {{{1
 


### PR DESCRIPTION
We document external artifacts to be under BUILDDIR.

MentorEmbedded/innexis-linux-docs@a9120a6:
`markdown/innexis_linux_rm/chapters/virtual_platform_bsps_innexis_hybrid.md#enable-custom-device-tree-optional`