### PR TITLE
flex-staging: Upgrade gstreamer and dependencies

### DIFF
--- a/meta-flex-distro/conf/distro/innexis-linux.conf
+++ b/meta-flex-distro/conf/distro/innexis-linux.conf
@@ -331,6 +331,14 @@ require ${@bb.utils.contains('USER_FEATURES', 'flex-ewaol-baremetal', 'conf/dist
 PREFERRED_VERSION_libdrm = "2.4.123"
 PREFERRED_VERSION_mesa   = "24.3.4"
 PREFERRED_VERSION_wayland-protocols = "1.38"
+PREFERRED_VERSION_gstreamer1.0 = "1.26.3"
+PREFERRED_VERSION_gstreamer1.0-plugins-base = "1.26.3"
+PREFERRED_VERSION_gstreamer1.0-plugins-good = "1.26.3"
+PREFERRED_VERSION_gstreamer1.0-plugins-bad = "1.26.3"
+PREFERRED_VERSION_gstreamer1.0-plugins-ugly = "1.26.3"
+PREFERRED_VERSION_gstreamer1.0-libav = "1.26.3"
+
+PACKAGECONFIG:remove:pn-gstreamer1.0-plugins-bad = "rsvg"
 
 # Enable the LLVM based Vulkan and OpenGL swrast drivers, depending on the
 # distro features supported by the BSPs

--- a/meta-flex-staging/recipes-devtools/meson/meson/0001-Make-CPU-family-warnings-fatal.patch
+++ b/meta-flex-staging/recipes-devtools/meson/meson/0001-Make-CPU-family-warnings-fatal.patch
@@ -1,0 +1,44 @@
+From c01e5e29953e0302988f2d60adc50ebfa0e5d670 Mon Sep 17 00:00:00 2001
+From: Ross Burton <ross.burton@intel.com>
+Date: Tue, 3 Jul 2018 13:59:09 +0100
+Subject: [PATCH] Make CPU family warnings fatal
+
+Upstream-Status: Inappropriate [OE specific]
+Signed-off-by: Ross Burton <ross.burton@intel.com>
+---
+ mesonbuild/envconfig.py   | 4 ++--
+ mesonbuild/environment.py | 6 ++----
+ 2 files changed, 4 insertions(+), 6 deletions(-)
+
+diff --git a/mesonbuild/envconfig.py b/mesonbuild/envconfig.py
+index 43fad0c..27be871 100644
+--- a/mesonbuild/envconfig.py
++++ b/mesonbuild/envconfig.py
+@@ -287,8 +287,8 @@ class MachineInfo(HoldableObject):
+                 'but is missing {}.'.format(minimum_literal - set(literal)))
+ 
+         cpu_family = literal['cpu_family']
+-        if cpu_family not in known_cpu_families:
+-            mlog.warning(f'Unknown CPU family {cpu_family}, please report this at https://github.com/mesonbuild/meson/issues/new')
++        if cpu_family not in known_cpu_families and cpu_family != "riscv":
++            raise EnvironmentException('Unknown CPU family {}, see https://wiki.yoctoproject.org/wiki/Meson/UnknownCPU for directions.'.format(cpu_family))
+ 
+         endian = literal['endian']
+         if endian not in ('little', 'big'):
+diff --git a/mesonbuild/environment.py b/mesonbuild/environment.py
+index 2a9cf16..6b2bd6b 100644
+--- a/mesonbuild/environment.py
++++ b/mesonbuild/environment.py
+@@ -436,10 +436,8 @@ def detect_cpu_family(compilers: CompilersDict) -> str:
+         if compilers and not any_compiler_has_define(compilers, '__mips64'):
+             trial = 'mips'
+ 
+-    if trial not in known_cpu_families:
+-        mlog.warning(f'Unknown CPU family {trial!r}, please report this at '
+-                     'https://github.com/mesonbuild/meson/issues/new with the '
+-                     'output of `uname -a` and `cat /proc/cpuinfo`')
++    if trial not in known_cpu_families and trail != "riscv":
++        raise EnvironmentException('Unknown CPU family %s, see https://wiki.yoctoproject.org/wiki/Meson/UnknownCPU for directions.' % trial)
+ 
+     return trial
+ 

--- a/meta-flex-staging/recipes-devtools/meson/meson/0001-python-module-do-not-manipulate-the-environment-when.patch
+++ b/meta-flex-staging/recipes-devtools/meson/meson/0001-python-module-do-not-manipulate-the-environment-when.patch
@@ -1,0 +1,37 @@
+From 6c3734f533ee7ad493188c8fc17bb1c65b65f0bd Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Mon, 19 Nov 2018 14:24:26 +0100
+Subject: [PATCH] python module: do not manipulate the environment when calling
+
+ pkg-config
+
+Upstream-Status: Inappropriate [oe-core specific]
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+---
+ mesonbuild/dependencies/python.py | 6 +-----
+ 1 file changed, 1 insertion(+), 5 deletions(-)
+
+diff --git a/mesonbuild/dependencies/python.py b/mesonbuild/dependencies/python.py
+index ab040b5..a34b271 100644
+--- a/mesonbuild/dependencies/python.py
++++ b/mesonbuild/dependencies/python.py
+@@ -412,9 +412,6 @@ def python_factory(env: 'Environment', for_machine: 'MachineChoice',
+                     empty.name = 'python'
+                     return empty
+ 
+-                old_pkg_libdir = os.environ.pop('PKG_CONFIG_LIBDIR', None)
+-                old_pkg_path = os.environ.pop('PKG_CONFIG_PATH', None)
+-                os.environ['PKG_CONFIG_LIBDIR'] = pkg_libdir
+                 try:
+                     return PythonPkgConfigDependency(name, env, kwargs, installation, True)
+                 finally:
+@@ -423,8 +420,7 @@ def python_factory(env: 'Environment', for_machine: 'MachineChoice',
+                             os.environ[name] = value
+                         elif name in os.environ:
+                             del os.environ[name]
+-                    set_env('PKG_CONFIG_LIBDIR', old_pkg_libdir)
+-                    set_env('PKG_CONFIG_PATH', old_pkg_path)
++                    pass
+ 
+             # Otherwise this doesn't fulfill the interface requirements
+             wrap_in_pythons_pc_dir.log_tried = PythonPkgConfigDependency.log_tried  # type: ignore[attr-defined]

--- a/meta-flex-staging/recipes-devtools/meson/meson/0002-Support-building-allarch-recipes-again.patch
+++ b/meta-flex-staging/recipes-devtools/meson/meson/0002-Support-building-allarch-recipes-again.patch
@@ -1,0 +1,25 @@
+From e123195e5990c3071385defd96dfab1211e98c08 Mon Sep 17 00:00:00 2001
+From: Peter Kjellerstedt <pkj@axis.com>
+Date: Thu, 26 Jul 2018 16:32:49 +0200
+Subject: [PATCH] Support building allarch recipes again
+
+This registers "allarch" as a known CPU family.
+
+Upstream-Status: Inappropriate [OE specific]
+Signed-off-by: Peter Kjellerstedt <peter.kjellerstedt@axis.com>
+---
+ mesonbuild/envconfig.py | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/mesonbuild/envconfig.py b/mesonbuild/envconfig.py
+index 27be871..994ac77 100644
+--- a/mesonbuild/envconfig.py
++++ b/mesonbuild/envconfig.py
+@@ -31,6 +31,7 @@ if T.TYPE_CHECKING:
+ 
+ 
+ known_cpu_families = (
++    'allarch',
+     'aarch64',
+     'alpha',
+     'arc',

--- a/meta-flex-staging/recipes-devtools/meson/meson/meson-setup.py
+++ b/meta-flex-staging/recipes-devtools/meson/meson/meson-setup.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+import os
+import string
+import sys
+
+class Template(string.Template):
+    delimiter = "@"
+
+class Environ():
+    def __getitem__(self, name):
+        val = os.environ[name]
+        val = val.split()
+        if len(val) > 1:
+            val = ["'%s'" % x for x in val]
+            val = ', '.join(val)
+            val = '[%s]' % val
+        elif val:
+            val = "'%s'" % val.pop()
+        return val
+
+try:
+    sysroot = os.environ['OECORE_NATIVE_SYSROOT']
+except KeyError:
+    print("Not in environment setup, bailing")
+    sys.exit(1)
+
+template_file = os.path.join(sysroot, 'usr/share/meson/meson.cross.template')
+cross_file = os.path.join(sysroot, 'usr/share/meson/%smeson.cross' % os.environ["TARGET_PREFIX"])
+native_template_file = os.path.join(sysroot, 'usr/share/meson/meson.native.template')
+native_file = os.path.join(sysroot, 'usr/share/meson/meson.native')
+
+with open(template_file) as in_file:
+    template = in_file.read()
+    output = Template(template).substitute(Environ())
+    with open(cross_file, "w") as out_file:
+        out_file.write(output)
+
+with open(native_template_file) as in_file:
+    template = in_file.read()
+    output = Template(template).substitute({'OECORE_NATIVE_SYSROOT': os.environ['OECORE_NATIVE_SYSROOT']})
+    with open(native_file, "w") as out_file:
+        out_file.write(output)

--- a/meta-flex-staging/recipes-devtools/meson/meson/meson-wrapper
+++ b/meta-flex-staging/recipes-devtools/meson/meson/meson-wrapper
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+if [ -z "$OECORE_NATIVE_SYSROOT" ]; then
+    exec "meson.real" "$@"
+fi
+
+if [ -z "$SSL_CERT_DIR" ]; then
+    export SSL_CERT_DIR="$OECORE_NATIVE_SYSROOT/etc/ssl/certs/"
+fi
+
+# If these are set to a cross-compile path, meson will get confused and try to
+# use them as native tools. Unset them to prevent this, as all the cross-compile
+# config is already in meson.cross.
+unset CC CXX CPP LD AR NM STRIP
+
+case "$1" in
+setup|configure|dist|install|introspect|init|test|wrap|subprojects|rewrite|compile|devenv|env2mfile|help)
+    MESON_CMD="$1"
+    shift
+    ;;
+*)
+    MESON_CMD=setup
+    echo meson-wrapper: Implicit setup command assumed
+    ;;
+esac
+
+if [ "$MESON_CMD" = "setup" ]; then
+    MESON_SETUP_OPTS=" \
+        --cross-file="$OECORE_NATIVE_SYSROOT/usr/share/meson/${TARGET_PREFIX}meson.cross" \
+        --native-file="$OECORE_NATIVE_SYSROOT/usr/share/meson/meson.native" \
+        "
+    echo meson-wrapper: Running meson with setup options: \"$MESON_SETUP_OPTS\"
+fi
+
+exec "$OECORE_NATIVE_SYSROOT/usr/bin/meson.real" \
+    $MESON_CMD \
+    $MESON_SETUP_OPTS \
+    "$@"

--- a/meta-flex-staging/recipes-devtools/meson/meson_1.8.2.bb
+++ b/meta-flex-staging/recipes-devtools/meson/meson_1.8.2.bb
@@ -1,0 +1,159 @@
+HOMEPAGE = "http://mesonbuild.com"
+SUMMARY = "A high performance build system"
+DESCRIPTION = "Meson is a build system designed to increase programmer \
+productivity. It does this by providing a fast, simple and easy to use \
+interface for modern software development tools and practices."
+
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://COPYING;md5=3b83ef96387f14655fc854ddc3c6bd57"
+
+GITHUB_BASE_URI = "https://github.com/mesonbuild/meson/releases/"
+SRC_URI = "${GITHUB_BASE_URI}/download/${PV}/meson-${PV}.tar.gz \
+           file://meson-setup.py \
+           file://meson-wrapper \
+           file://0001-python-module-do-not-manipulate-the-environment-when.patch \
+           file://0001-Make-CPU-family-warnings-fatal.patch \
+           file://0002-Support-building-allarch-recipes-again.patch \
+           "
+SRC_URI[sha256sum] = "c105816d8158c76b72adcb9ff60297719096da7d07f6b1f000fd8c013cd387af"
+UPSTREAM_CHECK_REGEX = "(?P<pver>\d+(\.\d+)+)$"
+
+inherit python_setuptools_build_meta github-releases
+
+RDEPENDS:${PN} = "ninja python3-modules python3-pkg-resources"
+
+FILES:${PN} += "${datadir}/polkit-1"
+
+BBCLASSEXTEND = "native nativesdk"
+
+inherit meson-routines
+
+# The cross file logic is similar but not identical to that in meson.bbclass,
+# since it's generating for an SDK rather than a cross-compile. Important
+# differences are:
+# - We can't set vars like CC, CXX, etc. yet because they will be filled in with
+#   real paths by meson-setup.sh when the SDK is extracted.
+# - Some overrides aren't needed, since the SDK injects paths that take care of
+#   them.
+def var_list2str(var, d):
+    items = d.getVar(var).split()
+    return repr(items[0]) if len(items) == 1 else ', '.join(repr(s) for s in items)
+
+def generate_native_link_template(d):
+    val = ['-L@{OECORE_NATIVE_SYSROOT}${libdir_native}',
+           '-L@{OECORE_NATIVE_SYSROOT}${base_libdir_native}',
+           '-Wl,-rpath-link,@{OECORE_NATIVE_SYSROOT}${libdir_native}',
+           '-Wl,-rpath-link,@{OECORE_NATIVE_SYSROOT}${base_libdir_native}',
+           '-Wl,--allow-shlib-undefined'
+        ]
+    build_arch = d.getVar('BUILD_ARCH')
+    if 'x86_64' in build_arch:
+        loader = 'ld-linux-x86-64.so.2'
+    elif 'i686' in build_arch:
+        loader = 'ld-linux.so.2'
+    elif 'aarch64' in build_arch:
+        loader = 'ld-linux-aarch64.so.1'
+    elif 'ppc64le' in build_arch:
+        loader = 'ld64.so.2'
+    elif 'loongarch64' in build_arch:
+        loader = 'ld-linux-loongarch-lp64d.so.1'
+    elif 'riscv64' in build_arch:
+        loader = 'ld-linux-riscv64-lp64d.so.1'
+
+    if loader:
+        val += ['-Wl,--dynamic-linker=@{OECORE_NATIVE_SYSROOT}${base_libdir_native}/' + loader]
+
+    return repr(val)
+
+install_native_template() {
+    install -d ${D}${datadir}/meson
+
+    cat >${D}${datadir}/meson/meson.native.template <<EOF
+[binaries]
+c = ${@meson_array('BUILD_CC', d)}
+cpp = ${@meson_array('BUILD_CXX', d)}
+ar = ${@meson_array('BUILD_AR', d)}
+nm = ${@meson_array('BUILD_NM', d)}
+strip = ${@meson_array('BUILD_STRIP', d)}
+readelf = ${@meson_array('BUILD_READELF', d)}
+pkg-config = 'pkg-config-native'
+
+[built-in options]
+c_args = ['-isystem@{OECORE_NATIVE_SYSROOT}${includedir_native}' , ${@var_list2str('BUILD_OPTIMIZATION', d)}]
+c_link_args = ${@generate_native_link_template(d)}
+cpp_args = ['-isystem@{OECORE_NATIVE_SYSROOT}${includedir_native}' , ${@var_list2str('BUILD_OPTIMIZATION', d)}]
+cpp_link_args = ${@generate_native_link_template(d)}
+EOF
+}
+
+install_nativesdk_template() {
+    install -d ${D}${datadir}/meson
+
+    cat >${D}${datadir}/meson/meson.native.template <<EOF
+[binaries]
+pkg-config = 'pkg-config-native'
+
+[built-in options]
+c_args = ['-isystem@{OECORE_NATIVE_SYSROOT}${includedir_native}']
+c_link_args = ['-L@{OECORE_NATIVE_SYSROOT}${libdir_native}', '-L@{OECORE_NATIVE_SYSROOT}${base_libdir_native}',]
+cpp_args = ['-isystem@{OECORE_NATIVE_SYSROOT}${includedir_native}']
+cpp_link_args = ['-L@{OECORE_NATIVE_SYSROOT}${libdir_native}', '-L@{OECORE_NATIVE_SYSROOT}${base_libdir_native}',]
+EOF
+}
+
+install_cross_template() {
+    install -d ${D}${datadir}/meson
+
+    cat >${D}${datadir}/meson/meson.cross.template <<EOF
+[binaries]
+c = @CC
+cpp = @CXX
+ar = @AR
+nm = @NM
+strip = @STRIP
+pkg-config = 'pkg-config'
+
+[built-in options]
+c_args = @CFLAGS
+c_link_args = @LDFLAGS
+cpp_args = @CPPFLAGS
+cpp_link_args = @LDFLAGS
+
+[properties]
+needs_exe_wrapper = true
+sys_root = @OECORE_TARGET_SYSROOT
+
+[host_machine]
+system = @OECORE_MESON_HOST_SYSTEM
+cpu_family = @OECORE_MESON_HOST_CPU_FAMILY
+cpu = @OECORE_MESON_HOST_CPU
+endian = @OECORE_MESON_HOST_ENDIAN
+EOF
+}
+
+do_install:append:class-nativesdk() {
+    install_nativesdk_template
+    install_cross_template
+
+    install -d ${D}${SDKPATHNATIVE}/post-relocate-setup.d
+    install -m 0755 ${WORKDIR}/meson-setup.py ${D}${SDKPATHNATIVE}/post-relocate-setup.d/
+
+    # We need to wrap the real meson with a thin env setup wrapper.
+    mv ${D}${bindir}/meson ${D}${bindir}/meson.real
+    install -m 0755 ${WORKDIR}/meson-wrapper ${D}${bindir}/meson
+}
+
+FILES:${PN}:append:class-nativesdk = "${datadir}/meson ${SDKPATHNATIVE}"
+
+do_install:append:class-native() {
+    install_native_template
+    install_cross_template
+
+    install -d ${D}${datadir}/post-relocate-setup.d
+    install -m 0755 ${WORKDIR}/meson-setup.py ${D}${datadir}/post-relocate-setup.d/
+
+    # We need to wrap the real meson with a thin wrapper that substitues native/cross files
+    # when running in a direct SDK environment.
+    mv ${D}${bindir}/meson ${D}${bindir}/meson.real
+    install -m 0755 ${WORKDIR}/meson-wrapper ${D}${bindir}/meson
+}

--- a/meta-flex-staging/recipes-multimedia/gstreamer/gst-devtools/0001-connect-has-a-different-signature-on-musl.patch
+++ b/meta-flex-staging/recipes-multimedia/gstreamer/gst-devtools/0001-connect-has-a-different-signature-on-musl.patch
@@ -1,0 +1,38 @@
+From 9ed608c901955b0906aac102d5d7ab06accee60e Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sun, 9 Sep 2018 17:38:10 -0700
+Subject: [PATCH] connect has a different signature on musl
+
+On linux when not using glibc and using musl for C library, connect
+API has a different signature, this patch fixes this so it can compile
+on musl, the functionality should remain same as it is immediately
+typcasted to struct sockaddr_in* type inside the function before use
+
+Upstream-Status: Submitted [https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/8767]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ validate/plugins/fault_injection/socket_interposer.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/validate/plugins/fault_injection/socket_interposer.c b/validate/plugins/fault_injection/socket_interposer.c
+index 53c1ebb..ad7adf8 100644
+--- a/validate/plugins/fault_injection/socket_interposer.c
++++ b/validate/plugins/fault_injection/socket_interposer.c
+@@ -100,10 +100,15 @@ socket_interposer_set_callback (struct sockaddr_in *addrin,
+ }
+ 
+ int
+-connect (int socket, const struct sockaddr_in *addrin, socklen_t address_len)
++#if defined(__linux__) && !defined(__GLIBC__)
++connect (int socket, const struct sockaddr *addr, socklen_t address_len)
++#else
++connect (int socket, const struct sockaddr_in *addr, socklen_t address_len)
++#endif
+ {
+   size_t i;
+   int override_errno = 0;
++  struct sockaddr_in* addrin = (struct sockaddr_in*)addr;
+   typedef ssize_t (*real_connect_fn) (int, const struct sockaddr_in *,
+       socklen_t);
+   static real_connect_fn real_connect = 0;

--- a/meta-flex-staging/recipes-multimedia/gstreamer/gst-devtools_1.26.3.bb
+++ b/meta-flex-staging/recipes-multimedia/gstreamer/gst-devtools_1.26.3.bb
@@ -1,0 +1,53 @@
+SUMMARY = "Gstreamer validation tool"
+DESCRIPTION = "A Tool to test GStreamer components"
+HOMEPAGE = "https://gstreamer.freedesktop.org/documentation/gst-devtools/index.html"
+SECTION = "multimedia"
+
+LICENSE = "LGPL-2.1-or-later"
+LIC_FILES_CHKSUM = "file://validate/COPYING;md5=a6f89e2100d9b6cdffcea4f398e37343"
+
+#S = "${WORKDIR}/gst-devtools-${PV}"
+
+SRC_URI = "https://gstreamer.freedesktop.org/src/gst-devtools/gst-devtools-${PV}.tar.xz \
+           file://0001-connect-has-a-different-signature-on-musl.patch \
+           "
+
+SRC_URI[sha256sum] = "4fde19c3c144834f8cb05c2ca3f14b3a50d395bad203d17f98a6e70c1672f2ba"
+
+DEPENDS = "json-glib glib-2.0 glib-2.0-native gstreamer1.0 gstreamer1.0-plugins-base"
+RRECOMMENDS:${PN} = "git"
+
+FILES:${PN} += "${datadir}/gstreamer-1.0/* ${libdir}/gst-validate-launcher/* ${libdir}/gstreamer-1.0/*"
+
+inherit meson pkgconfig gettext upstream-version-is-even gobject-introspection
+
+# TODO: put this in a gettext.bbclass patch
+def gettext_oemeson(d):
+    if d.getVar('USE_NLS') == 'no':
+        return '-Dnls=disabled'
+    # Remove the NLS bits if USE_NLS is no or INHIBIT_DEFAULT_DEPS is set
+    if d.getVar('INHIBIT_DEFAULT_DEPS') and not oe.utils.inherits(d, 'cross-canadian'):
+        return '-Dnls=disabled'
+    return '-Dnls=enabled'
+
+# Build GstValidateVideo
+PACKAGECONFIG[cairo] = "-Dcairo=enabled,-Dcairo=disabled,cairo"
+
+EXTRA_OEMESON += " \
+    -Ddoc=disabled \
+    -Ddebug_viewer=disabled \
+    -Dtests=disabled \
+    -Ddots_viewer=disabled \
+    -Dvalidate=enabled \
+    ${@gettext_oemeson(d)} \
+"
+
+do_install:append () {
+     for fn in ${bindir}/gst-validate-launcher \
+         ${libdir}/gst-validate-launcher/python/launcher/config.py; do
+             sed -i -e 's,${B},/usr/src/debug/${PN},g' -e 's,${S},/usr/src/debug/${PN},g' ${D}$fn
+     done
+}
+
+GIR_MESON_ENABLE_FLAG = "enabled"
+GIR_MESON_DISABLE_FLAG = "disabled"

--- a/meta-flex-staging/recipes-multimedia/gstreamer/gst-examples/0001-Make-player-examples-installable.patch
+++ b/meta-flex-staging/recipes-multimedia/gstreamer/gst-examples/0001-Make-player-examples-installable.patch
@@ -1,0 +1,37 @@
+From 7924016fce2d0b435891a335cdae52fc939c7e3b Mon Sep 17 00:00:00 2001
+From: Jussi Kukkonen <jussi.kukkonen@intel.com>
+Date: Thu, 17 Aug 2017 11:07:02 +0300
+Subject: [PATCH] Make player examples installable
+
+Signed-off-by: Jussi Kukkonen <jussi.kukkonen@intel.com>
+Upstream-Status: Denied [Upstream considers these code examples, for now a least]
+
+https://bugzilla.gnome.org/show_bug.cgi?id=777827
+
+---
+ playback/player/gst-play/meson.build | 1 +
+ playback/player/gtk/meson.build      | 1 +
+ 2 files changed, 2 insertions(+)
+
+Index: gst-examples/playback/player/gst-play/meson.build
+===================================================================
+--- gst-examples.orig/playback/player/gst-play/meson.build
++++ gst-examples/playback/player/gst-play/meson.build
+@@ -2,5 +2,6 @@ executable('gst-play',
+     ['gst-play.c',
+      'gst-play-kb.c',
+      'gst-play-kb.h'],
++    install: true,
+     dependencies : [gst_dep, dependency('gstreamer-play-1.0'), m_dep])
+ 
+Index: gst-examples/playback/player/gtk/meson.build
+===================================================================
+--- gst-examples.orig/playback/player/gtk/meson.build
++++ gst-examples/playback/player/gtk/meson.build
+@@ -20,5 +20,6 @@ if gtk_dep.found()
+        'gtk-video-renderer.h',
+        'gtk-video-renderer.c'],
+       c_args :  extra_c_args,
++      install: true,
+       dependencies : [gst_dep, gsttag_dep, gstplay_dep, gtk_dep, x11_dep])
+ endif

--- a/meta-flex-staging/recipes-multimedia/gstreamer/gst-examples/gst-player.desktop
+++ b/meta-flex-staging/recipes-multimedia/gstreamer/gst-examples/gst-player.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=Media Player
+Comment=Basic media player
+Icon=video-player
+TryExec=gtk-play
+Exec=gtk-play
+StartupNotify=true
+Terminal=false
+Type=Application
+Categories=GTK;AudioVideo;

--- a/meta-flex-staging/recipes-multimedia/gstreamer/gst-examples_1.26.3.bb
+++ b/meta-flex-staging/recipes-multimedia/gstreamer/gst-examples_1.26.3.bb
@@ -1,0 +1,38 @@
+SUMMARY = "GStreamer examples (including gtk-play, gst-play)"
+DESCRIPTION = "GStreamer example applications"
+HOMEPAGE = "https://gitlab.freedesktop.org/gstreamer/gst-examples"
+BUGTRACKER = "https://gitlab.freedesktop.org/gstreamer/gst-examples/-/issues"
+LICENSE = "LGPL-2.0-or-later"
+LIC_FILES_CHKSUM = "file://playback/player/gtk/gtk-play.c;beginline=1;endline=20;md5=f8c72dae3d36823ec716a9ebcae593b9"
+
+DEPENDS = "glib-2.0 gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-bad gtk+3 json-glib glib-2.0-native"
+
+SRC_URI = "git://gitlab.freedesktop.org/gstreamer/gstreamer.git;protocol=https;branch=1.26 \
+           file://0001-Make-player-examples-installable.patch \
+           file://gst-player.desktop \
+           "
+
+SRCREV = "87bc0c6e949e3dcc440658f78ef52aa8088cb62f"
+
+S = "${UNPACKDIR}/${BP}/subprojects/gst-examples"
+
+inherit meson pkgconfig features_check
+
+# gtk-play has runtime errors otherwise
+TARGET_LDFLAGS += "-rdynamic"
+
+UPSTREAM_CHECK_GITTAGREGEX = "^(?P<pver>\d+\.(\d*[02468])+(\.\d+)+)"
+
+ANY_OF_DISTRO_FEATURES = "${GTK3DISTROFEATURES}"
+
+do_install:append() {
+	install -m 0644 -D ${UNPACKDIR}/gst-player.desktop ${D}${datadir}/applications/gst-player.desktop
+}
+
+RDEPENDS:${PN} = "gstreamer1.0-plugins-base-playback"
+RRECOMMENDS:${PN} = "gstreamer1.0-plugins-base-meta \
+                     gstreamer1.0-plugins-good-meta \
+                     gstreamer1.0-plugins-bad-meta \
+                      ${@bb.utils.contains("LICENSE_FLAGS_ACCEPTED", "commercial", "gstreamer1.0-libav", "", d)} \
+                     ${@bb.utils.contains("LICENSE_FLAGS_ACCEPTED", "commercial", "gstreamer1.0-plugins-ugly-meta", "", d)}"
+RPROVIDES:${PN} += "gst-player gst-player-bin"

--- a/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0-libav_1.26.3.bb
+++ b/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0-libav_1.26.3.bb
@@ -1,0 +1,29 @@
+SUMMARY = "Libav-based GStreamer 1.x plugin"
+DESCRIPTION = "Contains a GStreamer plugin for using the encoders, decoders, \
+muxers, and demuxers provided by FFmpeg."
+HOMEPAGE = "http://gstreamer.freedesktop.org/"
+SECTION = "multimedia"
+
+# ffmpeg has comercial license flags so add it as we need ffmpeg as a dependency
+LICENSE_FLAGS = "commercial"
+LICENSE = "LGPL-2.1-or-later"
+LIC_FILES_CHKSUM = "file://COPYING;md5=69333daa044cb77e486cc36129f7a770 \
+                    file://ext/libav/gstav.h;beginline=1;endline=18;md5=a752c35267d8276fd9ca3db6994fca9c \
+                    "
+
+SRC_URI = "https://gstreamer.freedesktop.org/src/gst-libav/gst-libav-${PV}.tar.xz"
+SRC_URI[sha256sum] = "3ada7e50a3b9b8ba3e405b14c4021e25fbb10379f77d2ce490aa16523ed2724d"
+
+S = "${WORKDIR}/gst-libav-${PV}"
+
+DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base ffmpeg"
+
+inherit meson pkgconfig upstream-version-is-even
+
+EXTRA_OEMESON += " \
+    -Dtests=disabled \
+    -Ddoc=disabled \
+"
+
+FILES:${PN} += "${libdir}/gstreamer-1.0/*.so"
+FILES:${PN}-staticdev += "${libdir}/gstreamer-1.0/*.a"

--- a/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0-meta-base.bb
+++ b/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0-meta-base.bb
@@ -1,0 +1,67 @@
+SUMMARY = "Gstreamer1.0 package groups"
+LICENSE = "MIT"
+
+# Due to use of COMBINED_FEATURES
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
+
+COMMERCIAL_PLUGINS = "${COMMERCIAL_AUDIO_PLUGINS} ${COMMERCIAL_VIDEO_PLUGINS}"
+DEPENDS_UGLY = "${@'gstreamer1.0-plugins-ugly' if 'ugly' in COMMERCIAL_PLUGINS.split('-') else ''}"
+DEPENDS_BAD = "${@'gstreamer1.0-plugins-bad' if 'bad' in COMMERCIAL_PLUGINS.split('-') else ''}"
+DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-good ${DEPENDS_UGLY} ${DEPENDS_BAD}"
+
+PACKAGES = "\
+    gstreamer1.0-meta-base \
+    gstreamer1.0-meta-x11-base \
+    gstreamer1.0-meta-audio \
+    gstreamer1.0-meta-debug \
+    gstreamer1.0-meta-video"
+
+ALLOW_EMPTY:gstreamer1.0-meta-base = "1"
+ALLOW_EMPTY:gstreamer1.0-meta-x11-base = "1"
+ALLOW_EMPTY:gstreamer1.0-meta-audio = "1"
+ALLOW_EMPTY:gstreamer1.0-meta-debug = "1"
+ALLOW_EMPTY:gstreamer1.0-meta-video = "1"
+
+RDEPENDS:gstreamer1.0-meta-base = "\
+    ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'gstreamer1.0-meta-x11-base', '', d)} \
+    gstreamer1.0 \
+    gstreamer1.0-plugins-base-playback \
+    gstreamer1.0-plugins-base-gio \
+    ${@bb.utils.contains('COMBINED_FEATURES', 'alsa', 'gstreamer1.0-plugins-base-alsa', '',d)} \
+    gstreamer1.0-plugins-base-volume \
+    gstreamer1.0-plugins-base-audioconvert \
+    gstreamer1.0-plugins-base-audioresample \
+    gstreamer1.0-plugins-base-typefindfunctions \
+    gstreamer1.0-plugins-base-videoconvertscale \
+    gstreamer1.0-plugins-good-autodetect \
+    gstreamer1.0-plugins-good-soup"
+
+RRECOMMENDS:gstreamer1.0-meta-x11-base = "\
+    gstreamer1.0-plugins-base-ximagesink \
+    gstreamer1.0-plugins-base-xvimagesink"
+
+RDEPENDS:gstreamer1.0-meta-audio = "\
+    gstreamer1.0-meta-base \
+    gstreamer1.0-plugins-base-vorbis \
+    gstreamer1.0-plugins-base-ogg \
+    gstreamer1.0-plugins-good-wavparse \
+    gstreamer1.0-plugins-good-flac \
+    ${COMMERCIAL_AUDIO_PLUGINS}"
+
+RDEPENDS:gstreamer1.0-meta-debug = "\
+    gstreamer1.0-meta-base \
+    gstreamer1.0-plugins-good-debug \
+    gstreamer1.0-plugins-base-audiotestsrc \
+    gstreamer1.0-plugins-base-videotestsrc"
+
+RDEPENDS:gstreamer1.0-meta-video = "\
+    gstreamer1.0-meta-base \
+    gstreamer1.0-plugins-good-avi \
+    gstreamer1.0-plugins-good-matroska \
+    gstreamer1.0-plugins-base-theora \
+    ${COMMERCIAL_VIDEO_PLUGINS}"
+
+RRECOMMENDS:gstreamer1.0-meta-video = "\
+    gstreamer1.0-meta-audio"

--- a/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0001-fix-maybe-uninitialized-warnings-when-compiling-with.patch
+++ b/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0001-fix-maybe-uninitialized-warnings-when-compiling-with.patch
@@ -1,0 +1,25 @@
+From 9456674cea4a933d5fbc24230d307fe0f52588f3 Mon Sep 17 00:00:00 2001
+From: Andre McCurdy <armccurdy@gmail.com>
+Date: Tue, 26 Jan 2016 15:16:01 -0800
+Subject: [PATCH] fix maybe-uninitialized warnings when compiling with -Os
+
+Upstream-Status: Pending
+
+Signed-off-by: Andre McCurdy <armccurdy@gmail.com>
+---
+ gst-libs/gst/codecparsers/gstvc1parser.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gst-libs/gst/codecparsers/gstvc1parser.c b/gst-libs/gst/codecparsers/gstvc1parser.c
+index f9af175..6661e2e 100644
+--- a/gst-libs/gst/codecparsers/gstvc1parser.c
++++ b/gst-libs/gst/codecparsers/gstvc1parser.c
+@@ -1730,7 +1730,7 @@ gst_vc1_parse_sequence_layer (const guint8 * data, gsize size,
+     GstVC1SeqLayer * seqlayer)
+ {
+   guint32 tmp;
+-  guint8 tmp8;
++  guint8 tmp8 = 0;
+   guint8 structA[8] = { 0, };
+   guint8 structB[12] = { 0, };
+   GstBitReader br;

--- a/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0002-avoid-including-sys-poll.h-directly.patch
+++ b/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0002-avoid-including-sys-poll.h-directly.patch
@@ -1,0 +1,27 @@
+From dd2b92fb70fed2799809c423fea79221a3e17108 Mon Sep 17 00:00:00 2001
+From: Andre McCurdy <armccurdy@gmail.com>
+Date: Wed, 3 Feb 2016 18:05:41 -0800
+Subject: [PATCH] avoid including <sys/poll.h> directly
+
+musl libc generates warnings if <sys/poll.h> is included directly.
+
+Upstream-Status: Pending
+
+Signed-off-by: Andre McCurdy <armccurdy@gmail.com>
+---
+ sys/dvb/gstdvbsrc.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/sys/dvb/gstdvbsrc.c b/sys/dvb/gstdvbsrc.c
+index 33ee3ff..b8ddea9 100644
+--- a/sys/dvb/gstdvbsrc.c
++++ b/sys/dvb/gstdvbsrc.c
+@@ -98,7 +98,7 @@
+ #include <gst/gst.h>
+ #include <gst/glib-compat-private.h>
+ #include <sys/ioctl.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ #include <fcntl.h>
+ #include <errno.h>
+ #include <stdio.h>

--- a/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0004-opencv-resolve-missing-opencv-data-dir-in-yocto-buil.patch
+++ b/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0004-opencv-resolve-missing-opencv-data-dir-in-yocto-buil.patch
@@ -1,0 +1,32 @@
+From 11a08e3f3135b649b68714c77670c37559f3a33c Mon Sep 17 00:00:00 2001
+From: Andrey Zhizhikin <andrey.z@gmail.com>
+Date: Mon, 27 Jan 2020 10:22:35 +0000
+Subject: [PATCH] opencv: resolve missing opencv data dir in yocto build
+
+When Yocto build is performed, opencv searches for data dir using simple
+'test' command, this fails because pkg-config provides an absolute
+path on the target which needs to be prepended by PKG_CONFIG_SYSROOT_DIR
+in order for the 'test' utility to pick up the absolute path.
+
+Upstream-Status: Inappropriate [OE-specific]
+
+Signed-off-by: Andrey Zhizhikin <andrey.z@gmail.com>
+Signed-off-by: Jose Quaresma <quaresma.jose@gmail.com>
+---
+ gst-libs/gst/opencv/meson.build | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/gst-libs/gst/opencv/meson.build b/gst-libs/gst/opencv/meson.build
+index 64e913e..42a0958 100644
+--- a/gst-libs/gst/opencv/meson.build
++++ b/gst-libs/gst/opencv/meson.build
+@@ -61,6 +61,9 @@ gstopencv_cargs += ['-DOPENCV_PREFIX="' + opencv_prefix + '"']
+ # /usr/include/opencv4/opencv2/flann/logger.h:83:36: error: format string is not a string literal [-Werror,-Wformat-nonliteral]
+ gstopencv_cargs += cxx.get_supported_arguments(['-Wno-missing-include-dirs', '-Wno-format-nonliteral'])
+ 
++pkgconf_sysroot = run_command(python3, '-c', 'import os; print(os.environ.get("PKG_CONFIG_SYSROOT_DIR"))').stdout().strip()
++opencv_prefix = pkgconf_sysroot + opencv_prefix
++
+ # Check the data dir used by opencv for its xml data files
+ # Use prefix from pkg-config to be compatible with cross-compilation
+ fsmod = import('fs')

--- a/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.26.3.bb
+++ b/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.26.3.bb
@@ -1,0 +1,178 @@
+require gstreamer1.0-plugins-common.inc
+require gstreamer1.0-plugins-license.inc
+
+SUMMARY = "'Bad' GStreamer plugins and helper libraries "
+HOMEPAGE = "https://gstreamer.freedesktop.org/"
+BUGTRACKER = "https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/-/issues"
+
+SRC_URI = "https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-${PV}.tar.xz \
+           file://0001-fix-maybe-uninitialized-warnings-when-compiling-with.patch \
+           file://0002-avoid-including-sys-poll.h-directly.patch \
+           file://0004-opencv-resolve-missing-opencv-data-dir-in-yocto-buil.patch \
+           "
+SRC_URI[sha256sum] = "95c48dacaf14276f4e595f4cbca94b3cfebfc22285e765e2aa56d0a7275d7561"
+
+S = "${WORKDIR}/gst-plugins-bad-${PV}"
+
+LICENSE = "LGPL-2.1-or-later & GPL-2.0-or-later"
+LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
+
+DEPENDS += "gstreamer1.0-plugins-base"
+
+inherit gobject-introspection
+
+PACKAGECONFIG ??= " \
+    ${GSTREAMER_ORC} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'bluez', '', d)} \
+    ${@bb.utils.filter('DISTRO_FEATURES', 'directfb vulkan x11', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'wayland', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'gl', '', d)} \
+    bz2 closedcaption curl dash dtls hls openssl sbc smoothstreaming \
+    sndfile ttml uvch264 webp analytics \
+    ${@bb.utils.contains('TUNE_FEATURES', 'mx32', '', 'rsvg', d)} \
+"
+
+PACKAGECONFIG[analytics]       = "-Danalyticsoverlay=enabled,-Danalyticsoverlay=disabled,"
+PACKAGECONFIG[aom]             = "-Daom=enabled,-Daom=disabled,aom"
+PACKAGECONFIG[assrender]       = "-Dassrender=enabled,-Dassrender=disabled,libass"
+PACKAGECONFIG[avtp]            = "-Davtp=enabled,-Davtp=disabled,libavtp"
+PACKAGECONFIG[bluez]           = "-Dbluez=enabled,-Dbluez=disabled,bluez5"
+PACKAGECONFIG[bz2]             = "-Dbz2=enabled,-Dbz2=disabled,bzip2"
+PACKAGECONFIG[closedcaption]   = "-Dclosedcaption=enabled,-Dclosedcaption=disabled,pango cairo"
+PACKAGECONFIG[curl]            = "-Dcurl=enabled,-Dcurl=disabled,curl"
+PACKAGECONFIG[dash]            = "-Ddash=enabled,-Ddash=disabled,libxml2"
+PACKAGECONFIG[dc1394]          = "-Ddc1394=enabled,-Ddc1394=disabled,libdc1394"
+PACKAGECONFIG[directfb]        = "-Ddirectfb=enabled,-Ddirectfb=disabled,directfb"
+PACKAGECONFIG[dtls]            = "-Ddtls=enabled,-Ddtls=disabled,openssl"
+PACKAGECONFIG[faac]            = "-Dfaac=enabled,-Dfaac=disabled,faac"
+PACKAGECONFIG[faad]            = "-Dfaad=enabled,-Dfaad=disabled,faad2"
+PACKAGECONFIG[fluidsynth]      = "-Dfluidsynth=enabled,-Dfluidsynth=disabled,fluidsynth"
+PACKAGECONFIG[gtk3]            = "-Dgtk3=enabled,-Dgtk3=disabled,gtk3+"
+PACKAGECONFIG[hls]             = "-Dhls=enabled,-Dhls=disabled,"
+# Pick atleast one crypto backend below when enabling hls
+PACKAGECONFIG[nettle]          = "-Dhls-crypto=nettle,,nettle"
+PACKAGECONFIG[openssl]         = "-Dhls-crypto=openssl,,openssl"
+PACKAGECONFIG[gcrypt]          = "-Dhls-crypto=libgcrypt,,libgcrypt"
+# the gl packageconfig enables OpenGL elements that haven't been ported
+# to -base yet. They depend on the gstgl library in -base, so we do
+# not add GL dependencies here, since these are taken care of in -base.
+PACKAGECONFIG[gl]              = "-Dgl=enabled,-Dgl=disabled,"
+PACKAGECONFIG[kms]             = "-Dkms=enabled,-Dkms=disabled,libdrm"
+PACKAGECONFIG[libde265]        = "-Dlibde265=enabled,-Dlibde265=disabled,libde265"
+PACKAGECONFIG[libssh2]         = "-Dcurl-ssh2=enabled,-Dcurl-ssh2=disabled,libssh2"
+PACKAGECONFIG[lcms2]           = "-Dcolormanagement=enabled,-Dcolormanagement=disabled,lcms"
+PACKAGECONFIG[modplug]         = "-Dmodplug=enabled,-Dmodplug=disabled,libmodplug"
+PACKAGECONFIG[msdk]            = "-Dmsdk=enabled -Dmfx_api=oneVPL,-Dmsdk=disabled,vpl-gpu-rt"
+PACKAGECONFIG[neon]            = "-Dneon=enabled,-Dneon=disabled,neon"
+PACKAGECONFIG[openal]          = "-Dopenal=enabled,-Dopenal=disabled,openal-soft"
+PACKAGECONFIG[opencv]          = "-Dopencv=enabled,-Dopencv=disabled,opencv"
+PACKAGECONFIG[openh264]        = "-Dopenh264=enabled,-Dopenh264=disabled,openh264"
+PACKAGECONFIG[openjpeg]        = "-Dopenjpeg=enabled,-Dopenjpeg=disabled,openjpeg"
+PACKAGECONFIG[openmpt]         = "-Dopenmpt=enabled,-Dopenmpt=disabled,libopenmpt"
+# the opus encoder/decoder elements are now in the -base package,
+# but the opus parser remains in -bad
+PACKAGECONFIG[opusparse]       = "-Dopus=enabled,-Dopus=disabled,libopus"
+PACKAGECONFIG[resindvd]        = "-Dresindvd=enabled,-Dresindvd=disabled,libdvdread libdvdnav"
+PACKAGECONFIG[rsvg]            = "-Drsvg=enabled,-Drsvg=disabled,librsvg"
+PACKAGECONFIG[rtmp]            = "-Drtmp=enabled,-Drtmp=disabled,rtmpdump"
+PACKAGECONFIG[sbc]             = "-Dsbc=enabled,-Dsbc=disabled,sbc"
+PACKAGECONFIG[sctp]            = "-Dsctp=enabled,-Dsctp=disabled"
+PACKAGECONFIG[smoothstreaming] = "-Dsmoothstreaming=enabled,-Dsmoothstreaming=disabled,libxml2"
+PACKAGECONFIG[sndfile]         = "-Dsndfile=enabled,-Dsndfile=disabled,libsndfile1"
+PACKAGECONFIG[srt]             = "-Dsrt=enabled,-Dsrt=disabled,srt"
+PACKAGECONFIG[srtp]            = "-Dsrtp=enabled,-Dsrtp=disabled,libsrtp"
+PACKAGECONFIG[tinyalsa]        = "-Dtinyalsa=enabled,-Dtinyalsa=disabled,tinyalsa"
+PACKAGECONFIG[ttml]            = "-Dttml=enabled,-Dttml=disabled,libxml2 pango cairo"
+PACKAGECONFIG[uvch264]         = "-Duvch264=enabled,-Duvch264=disabled,libusb1 libgudev"
+# this enables support for stateless V4L2 mem2mem codecs, which is a newer form of
+# V4L2 codec; the V4L2 code in -base supports the older stateful V4L2 mem2mem codecs
+PACKAGECONFIG[v4l2codecs]      = "-Dv4l2codecs=enabled,-Dv4l2codecs=disabled,libgudev"
+PACKAGECONFIG[va]              = "-Dva=enabled,-Dva=disabled,libva"
+PACKAGECONFIG[voaacenc]        = "-Dvoaacenc=enabled,-Dvoaacenc=disabled,vo-aacenc"
+PACKAGECONFIG[voamrwbenc]      = "-Dvoamrwbenc=enabled,-Dvoamrwbenc=disabled,vo-amrwbenc"
+PACKAGECONFIG[vulkan]          = "-Dvulkan=enabled,-Dvulkan=disabled,vulkan-loader shaderc-native"
+PACKAGECONFIG[wayland]         = "-Dwayland=enabled,-Dwayland=disabled,wayland-native wayland wayland-protocols libdrm"
+PACKAGECONFIG[webp]            = "-Dwebp=enabled,-Dwebp=disabled,libwebp"
+PACKAGECONFIG[webrtc]          = "-Dwebrtc=enabled,-Dwebrtc=disabled,libnice"
+PACKAGECONFIG[webrtcdsp]       = "-Dwebrtcdsp=enabled,-Dwebrtcdsp=disabled,webrtc-audio-processing-1"
+PACKAGECONFIG[zbar]            = "-Dzbar=enabled,-Dzbar=disabled,zbar"
+PACKAGECONFIG[x11]             = "-Dx11=enabled,-Dx11=disabled,libxcb libxkbcommon"
+PACKAGECONFIG[x265]            = "-Dx265=enabled,-Dx265=disabled,x265"
+
+GSTREAMER_GPL = "${@bb.utils.filter('PACKAGECONFIG', 'faad resindvd x265', d)}"
+
+EXTRA_OEMESON += " \
+    -Ddoc=disabled \
+    -Daes=enabled \
+    -Dcodecalpha=enabled \
+    -Ddecklink=enabled \
+    -Ddvb=enabled \
+    -Dfbdev=enabled \
+    -Dipcpipeline=enabled \
+    -Dshm=enabled \
+    -Dtranscode=enabled \
+    -Dandroidmedia=disabled \
+    -Dapplemedia=disabled \
+    -Dasio=disabled \
+    -Dbs2b=disabled \
+    -Dchromaprint=disabled \
+    -Dd3dvideosink=disabled \
+    -Dd3d11=disabled \
+    -Ddirectsound=disabled \
+    -Ddts=disabled \
+    -Dfdkaac=disabled \
+    -Dflite=disabled \
+    -Dgme=disabled \
+    -Dgs=disabled \
+    -Dgsm=disabled \
+    -Diqa=disabled \
+    -Dladspa=disabled \
+    -Dldac=disabled \
+    -Dlv2=disabled \
+    -Dmagicleap=disabled \
+    -Dmediafoundation=disabled \
+    -Dmicrodns=disabled \
+    -Dmpeg2enc=disabled \
+    -Dmplex=disabled \
+    -Dmusepack=disabled \
+    -Dnvcodec=disabled \
+    -Dopenexr=disabled \
+    -Dopenni2=disabled \
+    -Dopenaptx=disabled \
+    -Dopensles=disabled \
+    -Donnx=disabled \
+    -Dqroverlay=disabled \
+    -Dsoundtouch=disabled \
+    -Dspandsp=disabled \
+    -Dsvthevcenc=disabled \
+    -Dteletext=disabled \
+    -Dwasapi=disabled \
+    -Dwasapi2=disabled \
+    -Dwildmidi=disabled \
+    -Dwinks=disabled \
+    -Dwinscreencap=disabled \
+    -Dwpe=disabled \
+    -Dzxing=disabled \
+    -Dlcevcdecoder=disabled \
+    -Dlcevcencoder=disabled \
+    -Dtensordecoders=disabled \
+    -Dnvcomp=disabled \
+    -Dnvdswrapper=disabled \
+    -Dsvtjpegxs=disabled \
+    -Dwebview2=disabled \
+    -Daja=disabled \
+    -Dcuda-nvmm=disabled \
+    -Dd3d12=disabled \
+"
+
+export OPENCV_PREFIX = "${STAGING_DIR_TARGET}${prefix}"
+
+ARM_INSTRUCTION_SET:armv4 = "arm"
+ARM_INSTRUCTION_SET:armv5 = "arm"
+
+CVE_PRODUCT = "gst-plugins-bad"
+
+FILES:${PN}-freeverb += "${datadir}/gstreamer-1.0/presets/GstFreeverb.prs"
+FILES:${PN}-opencv += "${datadir}/gst-plugins-bad/1.0/opencv*"
+FILES:${PN}-transcode += "${datadir}/gstreamer-1.0/encoding-profiles"
+FILES:${PN}-voamrwbenc += "${datadir}/gstreamer-1.0/presets/GstVoAmrwbEnc.prs"

--- a/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/0001-ENGR00312515-get-caps-from-src-pad-when-query-caps.patch
+++ b/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/0001-ENGR00312515-get-caps-from-src-pad-when-query-caps.patch
@@ -1,0 +1,41 @@
+From bd1436f0027bb09cdcf90386910a497422d9a871 Mon Sep 17 00:00:00 2001
+From: zhouming <b42586@freescale.com>
+Date: Wed, 14 May 2014 10:16:20 +0800
+Subject: [PATCH] ENGR00312515: get caps from src pad when query caps
+
+https://bugzilla.gnome.org/show_bug.cgi?id=728312
+
+Upstream-Status: Pending
+
+Signed-off-by: zhouming <b42586@freescale.com>
+---
+ gst-libs/gst/tag/gsttagdemux.c | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+ mode change 100644 => 100755 gst-libs/gst/tag/gsttagdemux.c
+
+diff --git a/gst-libs/gst/tag/gsttagdemux.c b/gst-libs/gst/tag/gsttagdemux.c
+old mode 100644
+new mode 100755
+index 975fe83..df82840
+--- a/gst-libs/gst/tag/gsttagdemux.c
++++ b/gst-libs/gst/tag/gsttagdemux.c
+@@ -1796,6 +1796,19 @@ gst_tag_demux_pad_query (GstPad * pad, GstObject * parent, GstQuery * query)
+       }
+       break;
+     }
++    case GST_QUERY_CAPS:
++    {
++
++      /* We can hijack caps query if we typefind already */
++      if (demux->priv->src_caps) {
++        gst_query_set_caps_result (query, demux->priv->src_caps);
++        res = TRUE;
++      } else {
++        res = gst_pad_query_default (pad, parent, query);
++      }
++      break;
++    }
++
+     default:
+       res = gst_pad_query_default (pad, parent, query);
+       break;

--- a/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/0002-ssaparse-enhance-SSA-text-lines-parsing.patch
+++ b/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/0002-ssaparse-enhance-SSA-text-lines-parsing.patch
@@ -1,0 +1,226 @@
+From 1cc876662b7707eb5a2f668654f7921b5642e108 Mon Sep 17 00:00:00 2001
+From: Mingke Wang <mingke.wang@freescale.com>
+Date: Thu, 19 Mar 2015 14:17:10 +0800
+Subject: [PATCH] ssaparse: enhance SSA text lines parsing.
+
+some parser will pass in the original ssa text line which starts with "Dialog:"
+and there's are maybe multiple Dialog lines in one input buffer.
+
+Upstream-Status: Submitted [https://gitlab.freedesktop.org/gstreamer/gst-plugins-base/-/issues/178]
+
+Signed-off-by: Mingke Wang <mingke.wang@freescale.com>
+---
+ gst/subparse/gstssaparse.c | 150 +++++++++++++++++++++++++++++++++----
+ 1 file changed, 134 insertions(+), 16 deletions(-)
+ mode change 100644 => 100755 gst/subparse/gstssaparse.c
+
+diff --git a/gst/subparse/gstssaparse.c b/gst/subparse/gstssaparse.c
+old mode 100644
+new mode 100755
+index c162a54..bd8afd9
+--- a/gst/subparse/gstssaparse.c
++++ b/gst/subparse/gstssaparse.c
+@@ -304,6 +304,7 @@ gst_ssa_parse_remove_override_codes (GstSsaParse * parse, gchar * txt)
+  * gst_ssa_parse_push_line:
+  * @parse: caller element
+  * @txt: text to push
++ * @size: text size need to be parse
+  * @start: timestamp for the buffer
+  * @duration: duration for the buffer
+  *
+@@ -313,27 +314,133 @@ gst_ssa_parse_remove_override_codes (GstSsaParse * parse, gchar * txt)
+  * Returns: result of the push of the created buffer
+  */
+ static GstFlowReturn
+-gst_ssa_parse_push_line (GstSsaParse * parse, gchar * txt,
++gst_ssa_parse_push_line (GstSsaParse * parse, gchar * txt, gint size,
+     GstClockTime start, GstClockTime duration)
+ {
+   GstFlowReturn ret;
+   GstBuffer *buf;
+-  gchar *t, *escaped;
++  gchar *t, *text, *p, *escaped, *p_start, *p_end;
+   gint num, i, len;
++  GstClockTime start_time = G_MAXUINT64, end_time = 0;
+ 
+-  num = atoi (txt);
+-  GST_LOG_OBJECT (parse, "Parsing line #%d at %" GST_TIME_FORMAT,
+-      num, GST_TIME_ARGS (start));
+-
+-  /* skip all non-text fields before the actual text */
++  p = text = g_malloc(size + 1);
++  *p = '\0';
+   t = txt;
+-  for (i = 0; i < 8; ++i) {
+-    t = strchr (t, ',');
++
++  /* there are may have multiple dialogue lines at a time */
++  while (*t) {
++    /* ignore leading white space characters */
++    while (isspace(*t))
++      t++;
++
++    /* ignore Format: and Style: lines */
++    if (strncmp(t, "Format:", 7) == 0 || strncmp(t, "Style:", 6) == 0) {
++      while (*t != '\0' && *t != '\n') {
++        t++;
++      }
++    }
++
++    if (*t == '\0')
++      break;
++
++    /* continue with next line */
++    if (*t == '\n') {
++      t++;
++      continue;
++    }
++
++    if(strncmp(t, "Dialogue:", 9) != 0) {
++      /* not started with "Dialogue:", it must be a line trimmed by demuxer */
++      num = atoi (t);
++      GST_LOG_OBJECT (parse, "Parsing line #%d at %" GST_TIME_FORMAT,
++          num, GST_TIME_ARGS (start));
++
++      /* skip all non-text fields before the actual text */
++      for (i = 0; i < 8; ++i) {
++        t = strchr (t, ',');
++        if (t == NULL)
++          break;
++        ++t;
++      }
++    } else {
++      /* started with "Dialogue:", update timestamp and duration */
++      /* time format are like Dialog:Mark,0:00:01.02,0:00:03.04,xx,xxx,... */
++      guint hour, min, sec, msec, len;
++      GstClockTime tmp;
++      gchar t_str[12] = {0};
++
++      /* find the first ',' */
++      p_start = strchr (t, ',');
++      if (p_start)
++        p_end = strchr (++p_start, ',');
++
++      if (p_start && p_end) {
++        /* copy text between first ',' and second ',' */
++        strncpy(t_str, p_start, p_end - p_start);
++        if (sscanf (t_str, "%u:%u:%u.%u", &hour, &min, &sec, &msec) == 4) {
++          tmp = ((hour*3600) + (min*60) + sec) * GST_SECOND + msec*GST_MSECOND;
++          GST_DEBUG_OBJECT (parse, "Get start time:%02d:%02d:%02d:%03d\n",
++              hour, min, sec, msec);
++          if (start_time > tmp)
++            start_time = tmp;
++        } else {
++          GST_WARNING_OBJECT (parse,
++              "failed to parse ssa start timestamp string :%s", t_str);
++        }
++
++        p_start = p_end;
++        p_end = strchr (++p_start, ',');
++        if (p_end) {
++          /* copy text between second ',' and third ',' */
++          strncpy(t_str, p_start, p_end - p_start);
++          if (sscanf (t_str, "%u:%u:%u.%u", &hour, &min, &sec, &msec) == 4) {
++            tmp = ((hour*3600) + (min*60) + sec)*GST_SECOND + msec*GST_MSECOND;
++            GST_DEBUG_OBJECT(parse, "Get end time:%02d:%02d:%02d:%03d\n",
++                hour, min, sec, msec);
++            if (end_time < tmp)
++              end_time = tmp;
++          } else {
++            GST_WARNING_OBJECT (parse,
++                "failed to parse ssa end timestamp string :%s", t_str);
++          }
++        }
++      }
++
++      /* now skip all non-text fields before the actual text */
++      for (i = 0; i <= 8; ++i) {
++        t = strchr (t, ',');
++        if (t == NULL)
++          break;
++        ++t;
++      }
++    }
++
++    /* line end before expected number of ',', not a Dialogue line */
+     if (t == NULL)
+-      return GST_FLOW_ERROR;
+-    ++t;
++      break;
++
++    /* if not the first line, and the last character of previous line is '\0',
++     * then replace it with '\N' */
++    if (p != text && *p == '\0') {
++      *p++ = '\\';
++      *p++ = 'N';
++    }
++
++    /* copy all actual text of this line */
++    while ((*t != '\0') && (*t != '\n'))
++      *p++ = *t++;
++
++    /* add a terminator at the end */
++    *p = '\0';
++  }
++
++  /* not valid text found in this buffer return OK to let caller unref buffer */
++  if (strlen(text) <= 0) {
++    GST_WARNING_OBJECT (parse, "Not valid text found in this buffer\n");
++    return GST_FLOW_ERROR;
+   }
+ 
++  t = text;
+   GST_LOG_OBJECT (parse, "Text : %s", t);
+ 
+   if (gst_ssa_parse_remove_override_codes (parse, t)) {
+@@ -351,13 +458,22 @@ gst_ssa_parse_push_line (GstSsaParse * parse, gchar * txt,
+   gst_buffer_fill (buf, 0, escaped, len + 1);
+   gst_buffer_set_size (buf, len);
+   g_free (escaped);
++  g_free(t);
++
++  if (start_time != G_MAXUINT64)
++    GST_BUFFER_TIMESTAMP (buf) = start_time;
++  else
++    GST_BUFFER_TIMESTAMP (buf) = start;
+ 
+-  GST_BUFFER_TIMESTAMP (buf) = start;
+-  GST_BUFFER_DURATION (buf) = duration;
++  if (end_time > start_time)
++    GST_BUFFER_DURATION (buf) = end_time - start_time;
++  else
++    GST_BUFFER_DURATION (buf) = duration;
+ 
+   GST_LOG_OBJECT (parse, "Pushing buffer with timestamp %" GST_TIME_FORMAT
+-      " and duration %" GST_TIME_FORMAT, GST_TIME_ARGS (start),
+-      GST_TIME_ARGS (duration));
++      " and duration %" GST_TIME_FORMAT,
++      GST_TIME_ARGS (GST_BUFFER_TIMESTAMP (buf)),
++      GST_TIME_ARGS (GST_BUFFER_DURATION (buf)));
+ 
+   ret = gst_pad_push (parse->srcpad, buf);
+ 
+@@ -377,6 +493,7 @@ gst_ssa_parse_chain (GstPad * sinkpad, GstObject * parent, GstBuffer * buf)
+   GstClockTime ts;
+   gchar *txt;
+   GstMapInfo map;
++  gint size;
+ 
+   if (G_UNLIKELY (!parse->framed))
+     goto not_framed;
+@@ -394,13 +511,14 @@ gst_ssa_parse_chain (GstPad * sinkpad, GstObject * parent, GstBuffer * buf)
+   /* make double-sure it's 0-terminated and all */
+   gst_buffer_map (buf, &map, GST_MAP_READ);
+   txt = g_strndup ((gchar *) map.data, map.size);
++  size = map.size;
+   gst_buffer_unmap (buf, &map);
+ 
+   if (txt == NULL)
+     goto empty_text;
+ 
+   ts = GST_BUFFER_TIMESTAMP (buf);
+-  ret = gst_ssa_parse_push_line (parse, txt, ts, GST_BUFFER_DURATION (buf));
++  ret = gst_ssa_parse_push_line (parse, txt, size, ts, GST_BUFFER_DURATION (buf));
+ 
+   if (ret != GST_FLOW_OK && GST_CLOCK_TIME_IS_VALID (ts)) {
+     GstSegment segment;

--- a/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/0003-viv-fb-Make-sure-config.h-is-included.patch
+++ b/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/0003-viv-fb-Make-sure-config.h-is-included.patch
@@ -1,0 +1,29 @@
+From c0c6944eca0c497477aa9f2cec2c83c4ea7a70e5 Mon Sep 17 00:00:00 2001
+From: Carlos Rafael Giani <crg7475@mailbox.org>
+Date: Tue, 21 May 2019 14:01:11 +0200
+Subject: [PATCH] viv-fb: Make sure config.h is included
+
+This prevents build errors due to missing GST_API_* symbols
+
+Upstream-Status: Pending
+
+Signed-off-by: Carlos Rafael Giani <crg7475@mailbox.org>
+---
+ gst-libs/gst/gl/gl-prelude.h | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/gst-libs/gst/gl/gl-prelude.h b/gst-libs/gst/gl/gl-prelude.h
+index 85fca5a..946c729 100644
+--- a/gst-libs/gst/gl/gl-prelude.h
++++ b/gst-libs/gst/gl/gl-prelude.h
+@@ -22,6 +22,10 @@
+ #ifndef __GST_GL_PRELUDE_H__
+ #define __GST_GL_PRELUDE_H__
+ 
++#ifdef HAVE_CONFIG_H
++#include "config.h"
++#endif
++
+ #include <gst/gst.h>
+ 
+ #ifdef BUILDING_GST_GL

--- a/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.26.3.bb
+++ b/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.26.3.bb
@@ -1,0 +1,96 @@
+require gstreamer1.0-plugins-common.inc
+
+SUMMARY = "'Base' GStreamer plugins and helper libraries"
+HOMEPAGE = "https://gstreamer.freedesktop.org/"
+BUGTRACKER = "https://gitlab.freedesktop.org/gstreamer/gst-plugins-base/-/issues"
+LICENSE = "LGPL-2.1-or-later"
+LIC_FILES_CHKSUM = "file://COPYING;md5=69333daa044cb77e486cc36129f7a770"
+
+SRC_URI = "https://gstreamer.freedesktop.org/src/gst-plugins-base/gst-plugins-base-${PV}.tar.xz \
+           file://0001-ENGR00312515-get-caps-from-src-pad-when-query-caps.patch \
+           file://0003-viv-fb-Make-sure-config.h-is-included.patch \
+           file://0002-ssaparse-enhance-SSA-text-lines-parsing.patch \
+           "
+SRC_URI[sha256sum] = "4ef9f9ef09025308ce220e2dd22a89e4c992d8ca71b968e3c70af0634ec27933"
+
+S = "${WORKDIR}/gst-plugins-base-${PV}"
+
+DEPENDS += "iso-codes util-linux zlib"
+
+inherit gobject-introspection
+
+# opengl packageconfig factored out to make it easy for distros
+# and BSP layers to choose OpenGL APIs/platforms/window systems
+PACKAGECONFIG_X11 = "${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'opengl glx', '', d)}"
+PACKAGECONFIG_GL ?= "${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'gles2 egl ${PACKAGECONFIG_X11}', '', d)}"
+
+PACKAGECONFIG ??= " \
+    ${GSTREAMER_ORC} \
+    ${PACKAGECONFIG_GL} \
+    ${@bb.utils.filter('DISTRO_FEATURES', 'alsa x11', d)} \
+    jpeg ogg pango png theora vorbis \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'wayland egl', '', d)} \
+"
+
+OPENGL_APIS = 'opengl gles2'
+OPENGL_PLATFORMS = 'egl glx'
+
+X11DEPENDS = "virtual/libx11 libsm libxrender libxv"
+X11ENABLEOPTS = "-Dx11=enabled -Dxvideo=enabled -Dxshm=enabled"
+X11DISABLEOPTS = "-Dx11=disabled -Dxvideo=disabled -Dxshm=disabled"
+
+PACKAGECONFIG[alsa]         = "-Dalsa=enabled,-Dalsa=disabled,alsa-lib"
+PACKAGECONFIG[cdparanoia]   = "-Dcdparanoia=enabled,-Dcdparanoia=disabled,cdparanoia"
+PACKAGECONFIG[graphene]     = "-Dgl-graphene=enabled,-Dgl-graphene=disabled,graphene"
+PACKAGECONFIG[jpeg]         = "-Dgl-jpeg=enabled,-Dgl-jpeg=disabled,jpeg"
+PACKAGECONFIG[ogg]          = "-Dogg=enabled,-Dogg=disabled,libogg"
+PACKAGECONFIG[opus]         = "-Dopus=enabled,-Dopus=disabled,libopus"
+PACKAGECONFIG[pango]        = "-Dpango=enabled,-Dpango=disabled,pango"
+PACKAGECONFIG[png]          = "-Dgl-png=enabled,-Dgl-png=disabled,libpng"
+# This enables Qt5 QML examples in -base. The Qt5 GStreamer
+# qmlglsink and qmlglsrc plugins still exist in -good.
+PACKAGECONFIG[qt5]          = "-Dqt5=enabled,-Dqt5=disabled,qtbase qtdeclarative qtbase-native"
+PACKAGECONFIG[theora]       = "-Dtheora=enabled,-Dtheora=disabled,libtheora"
+PACKAGECONFIG[tremor]       = "-Dtremor=enabled,-Dtremor=disabled,tremor"
+PACKAGECONFIG[visual]       = "-Dlibvisual=enabled,-Dlibvisual=disabled,libvisual"
+PACKAGECONFIG[vorbis]       = "-Dvorbis=enabled,-Dvorbis=disabled,libvorbis"
+PACKAGECONFIG[x11]          = "${X11ENABLEOPTS},${X11DISABLEOPTS},${X11DEPENDS}"
+
+# OpenGL API packageconfigs
+PACKAGECONFIG[opengl]       = ",,virtual/libgl libglu"
+PACKAGECONFIG[gles2]        = ",,virtual/libgles2"
+
+# OpenGL platform packageconfigs
+PACKAGECONFIG[egl]          = ",,virtual/egl"
+PACKAGECONFIG[glx]          = ",,virtual/libgl"
+
+# OpenGL window systems (except for X11)
+PACKAGECONFIG[gbm]          = ",,virtual/libgbm libgudev libdrm"
+PACKAGECONFIG[wayland]      = ",,wayland-native wayland wayland-protocols libdrm"
+PACKAGECONFIG[dispmanx]     = ",,virtual/libomxil"
+PACKAGECONFIG[viv-fb]       = ",,virtual/libgles2 virtual/libg2d"
+
+OPENGL_WINSYS = "${@bb.utils.filter('PACKAGECONFIG', 'x11 gbm wayland dispmanx egl viv-fb', d)}"
+
+EXTRA_OEMESON += " \
+    -Ddoc=disabled \
+    ${@get_opengl_cmdline_list('gl_api', d.getVar('OPENGL_APIS'), d)} \
+    ${@get_opengl_cmdline_list('gl_platform', d.getVar('OPENGL_PLATFORMS'), d)} \
+    ${@get_opengl_cmdline_list('gl_winsys', d.getVar('OPENGL_WINSYS'), d)} \
+"
+
+FILES:${PN}-dev += "${libdir}/gstreamer-1.0/include/gst/gl/gstglconfig.h"
+FILES:${MLPREFIX}libgsttag-1.0 += "${datadir}/gst-plugins-base/1.0/license-translations.dict"
+
+def get_opengl_cmdline_list(switch_name, options, d):
+    selected_options = []
+    if bb.utils.contains('DISTRO_FEATURES', 'opengl', True, False, d):
+        for option in options.split():
+            if bb.utils.contains('PACKAGECONFIG', option, True, False, d):
+                selected_options += [option]
+    if selected_options:
+        return '-D' + switch_name + '=' + ','.join(selected_options)
+    else:
+        return ''
+
+CVE_PRODUCT += "gst-plugins-base"

--- a/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0-plugins-common.inc
+++ b/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0-plugins-common.inc
@@ -1,0 +1,47 @@
+# This .inc file contains the common setup for the gstreamer1.0-plugins-*
+# plugin set recipes.
+
+# SUMMARY is set in the actual .bb recipes
+HOMEPAGE = "https://gstreamer.freedesktop.org/"
+BUGTRACKER = "https://bugzilla.gnome.org/enter_bug.cgi?product=Gstreamer"
+SECTION = "multimedia"
+
+DEPENDS = "gstreamer1.0 glib-2.0-native"
+
+inherit gettext meson pkgconfig upstream-version-is-even
+
+require gstreamer1.0-plugins-packaging.inc
+
+# Orc enables runtime JIT compilation of data processing routines from Orc
+# bytecode to SIMD instructions for various architectures (currently SSE, MMX,
+# MIPS, Altivec and NEON are supported).
+# This value is used in the PACKAGECONFIG values for each plugin set recipe.
+# By modifying it, Orc can be enabled/disabled in all of these recipes at once.
+GSTREAMER_ORC ?= "orc"
+# workaround to disable orc on mips to fix the build failure
+# {standard input}: Assembler messages:
+# {standard input}:46587: Error: branch out of range
+GSTREAMER_ORC:mips = ""
+PACKAGECONFIG[orc] = "-Dorc=enabled,-Dorc=disabled,orc orc-native"
+
+# TODO: put this in a gettext.bbclass patch (with variables to allow for
+# configuring the option name and the enabled/disabled values).
+def gettext_oemeson(d):
+    if d.getVar('USE_NLS') == 'no':
+        return '-Dnls=disabled'
+    # Remove the NLS bits if USE_NLS is no or INHIBIT_DEFAULT_DEPS is set
+    if d.getVar('INHIBIT_DEFAULT_DEPS') and not oe.utils.inherits(d, 'cross-canadian'):
+        return '-Dnls=disabled'
+    return '-Dnls=enabled'
+
+# Not all plugin sets contain examples, so the -Dexamples
+# option needs to be added conditionally.
+GST_PLUGIN_SET_HAS_EXAMPLES ?= "1"
+
+EXTRA_OEMESON += " \
+    ${@bb.utils.contains('GST_PLUGIN_SET_HAS_EXAMPLES', '1', '-Dexamples=disabled', '', d)} \
+    ${@gettext_oemeson(d)} \
+"
+
+GIR_MESON_ENABLE_FLAG = "enabled"
+GIR_MESON_DISABLE_FLAG = "disabled"

--- a/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.26.3.bb
+++ b/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.26.3.bb
@@ -1,0 +1,81 @@
+require gstreamer1.0-plugins-common.inc
+
+SUMMARY = "'Good' GStreamer plugins"
+HOMEPAGE = "https://gstreamer.freedesktop.org/"
+BUGTRACKER = "https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/issues"
+
+SRC_URI = "https://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plugins-good-${PV}.tar.xz"
+
+SRC_URI[sha256sum] = "fe4ec9670edfe6bb1e5f27169ae145b5ac2dd218ac98bd8251c8fba41ad33c53"
+
+S = "${WORKDIR}/gst-plugins-good-${PV}"
+
+LICENSE = "LGPL-2.1-or-later"
+LIC_FILES_CHKSUM = "file://COPYING;md5=a6f89e2100d9b6cdffcea4f398e37343 \
+                    file://gst/replaygain/rganalysis.c;beginline=1;endline=23;md5=b60ebefd5b2f5a8e0cab6bfee391a5fe"
+
+DEPENDS += "gstreamer1.0-plugins-base libcap zlib"
+RPROVIDES:${PN}-pulseaudio += "${PN}-pulse"
+RPROVIDES:${PN}-soup += "${PN}-souphttpsrc"
+RDEPENDS:${PN}-soup += "${MLPREFIX}${@bb.utils.contains('PACKAGECONFIG', 'soup2', 'libsoup-2.4', 'libsoup', d)}"
+
+PACKAGECONFIG_SOUP ?= "soup3"
+
+PACKAGECONFIG ??= " \
+    ${GSTREAMER_ORC} \
+    ${PACKAGECONFIG_SOUP} \
+    ${@bb.utils.filter('DISTRO_FEATURES', 'pulseaudio x11', d)} \
+    ${@bb.utils.contains('TUNE_FEATURES', 'm64', 'asm', '', d)} \
+    bz2 cairo flac gdk-pixbuf gudev jpeg lame libpng mpg123 speex taglib v4l2 \
+"
+
+X11DEPENDS = "virtual/libx11 libsm libxrender libxfixes libxdamage"
+X11ENABLEOPTS = "-Dximagesrc=enabled -Dximagesrc-xshm=enabled -Dximagesrc-xfixes=enabled -Dximagesrc-xdamage=enabled"
+X11DISABLEOPTS = "-Dximagesrc=disabled -Dximagesrc-xshm=disabled -Dximagesrc-xfixes=disabled -Dximagesrc-xdamage=disabled"
+
+QT5WAYLANDDEPENDS = "${@bb.utils.contains("DISTRO_FEATURES", "wayland", "qtwayland", "", d)}"
+
+PACKAGECONFIG[amrnb]      = "-Damrnb=enabled,-Damrnb=disabled,opencore-amr"
+PACKAGECONFIG[amrwb]      = "-Damrwbdec=enabled,-Damrwbdec=disabled,opencore-amr"
+PACKAGECONFIG[asm]        = "-Dasm=enabled,-Dasm=disabled,nasm-native"
+PACKAGECONFIG[bz2]        = "-Dbz2=enabled,-Dbz2=disabled,bzip2"
+PACKAGECONFIG[cairo]      = "-Dcairo=enabled,-Dcairo=disabled,cairo"
+PACKAGECONFIG[dv1394]     = "-Ddv1394=enabled,-Ddv1394=disabled,libiec61883 libavc1394 libraw1394"
+PACKAGECONFIG[flac]       = "-Dflac=enabled,-Dflac=disabled,flac"
+PACKAGECONFIG[gdk-pixbuf] = "-Dgdk-pixbuf=enabled,-Dgdk-pixbuf=disabled,gdk-pixbuf"
+PACKAGECONFIG[gtk]        = "-Dgtk3=enabled,-Dgtk3=disabled,gtk+3"
+PACKAGECONFIG[gudev]      = "-Dv4l2-gudev=enabled,-Dv4l2-gudev=disabled,libgudev"
+PACKAGECONFIG[jack]       = "-Djack=enabled,-Djack=disabled,jack"
+PACKAGECONFIG[jpeg]       = "-Djpeg=enabled,-Djpeg=disabled,jpeg"
+PACKAGECONFIG[lame]       = "-Dlame=enabled,-Dlame=disabled,lame"
+PACKAGECONFIG[libpng]     = "-Dpng=enabled,-Dpng=disabled,libpng"
+PACKAGECONFIG[libv4l2]    = "-Dv4l2-libv4l2=enabled,-Dv4l2-libv4l2=disabled,v4l-utils"
+PACKAGECONFIG[mpg123]     = "-Dmpg123=enabled,-Dmpg123=disabled,mpg123"
+PACKAGECONFIG[pulseaudio] = "-Dpulse=enabled,-Dpulse=disabled,pulseaudio"
+PACKAGECONFIG[qt5]        = "-Dqt5=enabled,-Dqt5=disabled,qtbase qtdeclarative qtbase-native qttools-native ${QT5WAYLANDDEPENDS}"
+PACKAGECONFIG[soup2]      = "-Dsoup=enabled,,libsoup-2.4,,,soup3"
+PACKAGECONFIG[soup3]      = "-Dsoup=enabled,,libsoup,,,soup2"
+PACKAGECONFIG[speex]      = "-Dspeex=enabled,-Dspeex=disabled,speex"
+PACKAGECONFIG[rpi]        = "-Drpicamsrc=enabled,-Drpicamsrc=disabled,userland"
+PACKAGECONFIG[taglib]     = "-Dtaglib=enabled,-Dtaglib=disabled,taglib"
+PACKAGECONFIG[v4l2]       = "-Dv4l2=enabled -Dv4l2-probe=true,-Dv4l2=disabled -Dv4l2-probe=false"
+PACKAGECONFIG[vpx]        = "-Dvpx=enabled,-Dvpx=disabled,libvpx"
+PACKAGECONFIG[wavpack]    = "-Dwavpack=enabled,-Dwavpack=disabled,wavpack"
+PACKAGECONFIG[x11]        = "${X11ENABLEOPTS},${X11DISABLEOPTS},${X11DEPENDS}"
+
+EXTRA_OEMESON += " \
+    -Ddoc=disabled \
+    -Daalib=disabled \
+    -Ddirectsound=disabled \
+    -Ddv=disabled \
+    -Dlibcaca=disabled \
+    -Doss=enabled \
+    -Doss4=disabled \
+    -Dosxaudio=disabled \
+    -Dosxvideo=disabled \
+    -Dshout2=disabled \
+    -Dtwolame=disabled \
+    -Dwaveform=disabled \
+"
+
+FILES:${PN}-equalizer += "${datadir}/gstreamer-1.0/presets/*.prs"

--- a/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0-plugins-license.inc
+++ b/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0-plugins-license.inc
@@ -1,0 +1,19 @@
+# This .inc file contains functionality for automatically setting
+# the the license of all plugins according to the GSTREAMER_GPL.
+
+PACKAGESPLITFUNCS += "set_gstreamer_license"
+
+python set_gstreamer_license () {
+    import oe.utils
+    pn = d.getVar('PN') + '-'
+    gpl_plugins_names = [pn+plugin for plugin in d.getVar('GSTREAMER_GPL').split()]
+    for pkg in oe.utils.packages_filter_out_system(d):
+        if pkg in gpl_plugins_names:
+            d.setVar('LICENSE:' + pkg, 'GPL-2.0-or-later')
+        else:
+            d.setVar('LICENSE:' + pkg, 'LGPL-2.1-or-later')
+}
+
+EXTRA_OEMESON += " \
+    ${@bb.utils.contains_any('PACKAGECONFIG', "${GSTREAMER_GPL}", '-Dgpl=enabled', '-Dgpl=disabled', d)} \
+    "

--- a/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0-plugins-packaging.inc
+++ b/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0-plugins-packaging.inc
@@ -1,0 +1,73 @@
+# This .inc file contains functionality for automatically splitting
+# built plugins into individual packages for each plugin. A -meta
+# package is also set up that has no files of its own, but contains
+# the names of all plugin packages in its RDEPENDS list.
+#
+# This is mainly used by the gstreamer1.0-plugins-* plugin set recipes,
+# but can be used in any recipe that produces GStreamer plugins.
+
+# Dynamically generate packages for all enabled plugins
+PACKAGES_DYNAMIC = "^${PN}-.* ^libgst.*"
+
+PACKAGESPLITFUNCS =+ "split_gstreamer10_packages"
+PACKAGESPLITFUNCS += "set_gstreamer10_metapkg_rdepends"
+
+python split_gstreamer10_packages () {
+    gst_libdir = d.expand('${libdir}/gstreamer-1.0')
+    postinst = d.getVar('plugin_postinst')
+    glibdir = d.getVar('libdir')
+
+    # GStreamer libraries
+    do_split_packages(d, glibdir, r'^lib(.*)\.so\.*', 'lib%s', 'GStreamer 1.0 %s library', extra_depends='', allow_links=True)
+    # GStreamer plugin shared objects
+    do_split_packages(d, gst_libdir, r'libgst(.*)\.so$', d.expand('${PN}-%s'), 'GStreamer 1.0 plugin for %s', postinst=postinst, extra_depends='')
+    # GObject introspection files for GStreamer plugins
+    do_split_packages(d, glibdir+'/girepository-1.0', r'Gst(.*)-1.0\.typelib$', d.expand('${PN}-%s-typelib'), 'GStreamer 1.0 typelib file for %s', postinst=postinst, extra_depends='')
+    # Static GStreamer libraries for development
+    do_split_packages(d, gst_libdir, r'libgst(.*)\.a$', d.expand('${PN}-%s-staticdev'), 'GStreamer 1.0 plugin for %s (static development files)', extra_depends='${PN}-staticdev')
+}
+
+python set_gstreamer10_metapkg_rdepends () {
+    import os
+    import oe.utils
+
+    # Go through all generated packages (excluding the main package and
+    # the -meta package itself) and add them to the -meta package as RDEPENDS.
+
+    pn = d.getVar('PN')
+    metapkg =  pn + '-meta'
+    d.setVar('ALLOW_EMPTY:' + metapkg, "1")
+    d.setVar('FILES:' + metapkg, "")
+    exclude = [ pn, pn + '-meta' ]
+    metapkg_rdepends = []
+    pkgdest = d.getVar('PKGDEST')
+    for pkg in oe.utils.packages_filter_out_system(d):
+        if pkg not in exclude and pkg not in metapkg_rdepends:
+            # See if the package is empty by looking at the contents of its PKGDEST subdirectory.
+            # If this subdirectory is empty, then the package is.
+            # Empty packages do not get added to the meta package's RDEPENDS
+            pkgdir = os.path.join(pkgdest, pkg)
+            if os.path.exists(pkgdir):
+                dir_contents = os.listdir(pkgdir) or []
+            else:
+                dir_contents = []
+            is_empty = len(dir_contents) == 0
+            if not is_empty:
+                metapkg_rdepends.append(pkg)
+    d.setVar('RDEPENDS:' + metapkg, ' '.join(metapkg_rdepends))
+    d.setVar('DESCRIPTION:' + metapkg, pn + ' meta package')
+}
+
+# each plugin-dev depends on PN-dev, plugin-staticdev on PN-staticdev
+# so we need them even when empty (like in gst-plugins-good case)
+ALLOW_EMPTY:${PN} = "1"
+ALLOW_EMPTY:${PN}-dev = "1"
+ALLOW_EMPTY:${PN}-staticdev = "1"
+
+PACKAGES += "${PN}-apps ${PN}-meta ${PN}-glib"
+
+FILES:${PN} = ""
+FILES:${PN}-apps = "${bindir}"
+FILES:${PN}-glib = "${datadir}/glib-2.0"
+
+RRECOMMENDS:${PN} += "${PN}-meta"

--- a/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_1.26.3.bb
+++ b/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_1.26.3.bb
@@ -1,0 +1,44 @@
+require gstreamer1.0-plugins-common.inc
+require gstreamer1.0-plugins-license.inc
+
+SUMMARY = "'Ugly GStreamer plugins"
+HOMEPAGE = "https://gstreamer.freedesktop.org/"
+BUGTRACKER = "https://gitlab.freedesktop.org/gstreamer/gst-plugins-ugly/-/issues"
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=a6f89e2100d9b6cdffcea4f398e37343 \
+                   "
+
+LICENSE = "LGPL-2.1-or-later & GPL-2.0-or-later"
+LICENSE_FLAGS = "commercial"
+
+SRC_URI = " \
+            https://gstreamer.freedesktop.org/src/gst-plugins-ugly/gst-plugins-ugly-${PV}.tar.xz \
+            "
+
+SRC_URI[sha256sum] = "417f5ee895f734ac0341b3719c175fff16b4c8eae8806e29e170b3bcb3d9dba5"
+
+S = "${WORKDIR}/gst-plugins-ugly-${PV}"
+
+DEPENDS += "gstreamer1.0-plugins-base"
+
+GST_PLUGIN_SET_HAS_EXAMPLES = "0"
+
+PACKAGECONFIG ??= " \
+    ${GSTREAMER_ORC} \
+"
+
+PACKAGECONFIG[a52dec]   = "-Da52dec=enabled,-Da52dec=disabled,liba52"
+PACKAGECONFIG[cdio]     = "-Dcdio=enabled,-Dcdio=disabled,libcdio"
+PACKAGECONFIG[dvdread]  = "-Ddvdread=enabled,-Ddvdread=disabled,libdvdread"
+PACKAGECONFIG[mpeg2dec] = "-Dmpeg2dec=enabled,-Dmpeg2dec=disabled,mpeg2dec"
+PACKAGECONFIG[x264]     = "-Dx264=enabled,-Dx264=disabled,x264"
+
+GSTREAMER_GPL = "${@bb.utils.filter('PACKAGECONFIG', 'a52dec cdio dvdread mpeg2dec x264', d)}"
+
+EXTRA_OEMESON += " \
+    -Ddoc=disabled \
+    -Dsidplay=disabled \
+"
+
+FILES:${PN}-amrnb += "${datadir}/gstreamer-1.0/presets/GstAmrnbEnc.prs"
+FILES:${PN}-x264 += "${datadir}/gstreamer-1.0/presets/GstX264Enc.prs"

--- a/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0-python_1.26.3.bb
+++ b/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0-python_1.26.3.bb
@@ -1,0 +1,30 @@
+SUMMARY = "Python bindings for GStreamer 1.0"
+DESCRIPTION = "GStreamer Python binding overrides (complementing the bindings \
+provided by python-gi) "
+HOMEPAGE = "http://cgit.freedesktop.org/gstreamer/gst-python/"
+SECTION = "multimedia"
+
+LICENSE = "LGPL-2.1-or-later"
+LIC_FILES_CHKSUM = "file://COPYING;md5=c34deae4e395ca07e725ab0076a5f740"
+
+SRC_URI = "https://gstreamer.freedesktop.org/src/${PNREAL}/${PNREAL}-${PV}.tar.xz"
+SRC_URI[sha256sum] = "9343b9a7c45f472498c24ddb6fea9aba5f1a24395ddbc0b79da6e485e42d1b12"
+
+DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base python3-pygobject gstreamer1.0-plugins-bad"
+RDEPENDS:${PN} += "gstreamer1.0 gstreamer1.0-plugins-base python3-pygobject"
+
+PNREAL = "gst-python"
+
+S = "${WORKDIR}/${PNREAL}-${PV}"
+
+EXTRA_OEMESON += "\
+    -Dtests=disabled \
+    -Dplugin=enabled \
+    -Dlibpython-dir=${libdir} \
+"
+
+inherit meson pkgconfig setuptools3-base upstream-version-is-even features_check
+
+FILES:${PN} += "${libdir}/gstreamer-1.0"
+
+REQUIRED_DISTRO_FEATURES = "gobject-introspection-data"

--- a/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0-rtsp-server_1.26.3.bb
+++ b/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0-rtsp-server_1.26.3.bb
@@ -1,0 +1,31 @@
+SUMMARY = "A library on top of GStreamer for building an RTSP server"
+HOMEPAGE = "http://cgit.freedesktop.org/gstreamer/gst-rtsp-server/"
+SECTION = "multimedia"
+LICENSE = "LGPL-2.1-or-later"
+LIC_FILES_CHKSUM = "file://COPYING;md5=69333daa044cb77e486cc36129f7a770"
+
+DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base"
+
+PNREAL = "gst-rtsp-server"
+
+SRC_URI = "https://gstreamer.freedesktop.org/src/${PNREAL}/${PNREAL}-${PV}.tar.xz"
+
+SRC_URI[sha256sum] = "415e8a53a9844789770dd4f116ac2e3a4a33de42673c57acc25c5ba0f4406fc5"
+
+S = "${WORKDIR}/${PNREAL}-${PV}"
+
+inherit meson pkgconfig upstream-version-is-even gobject-introspection
+
+EXTRA_OEMESON += " \
+    -Ddoc=disabled \
+    -Dexamples=disabled \
+    -Dtests=disabled \
+"
+
+GIR_MESON_ENABLE_FLAG = "enabled"
+GIR_MESON_DISABLE_FLAG = "disabled"
+
+# Starting with 1.8.0 gst-rtsp-server includes dependency-less plugins as well
+require gstreamer1.0-plugins-packaging.inc
+
+CVE_PRODUCT += "gst-rtsp-server"

--- a/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0-vaapi_1.26.3.bb
+++ b/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0-vaapi_1.26.3.bb
@@ -1,0 +1,53 @@
+SUMMARY = "VA-API support to GStreamer"
+HOMEPAGE = "https://gstreamer.freedesktop.org/"
+DESCRIPTION = "gstreamer-vaapi consists of a collection of VA-API \
+based plugins for GStreamer and helper libraries: `vaapidecode', \
+`vaapiconvert', and `vaapisink'."
+
+REALPN = "gstreamer-vaapi"
+
+LICENSE = "LGPL-2.1-or-later"
+LIC_FILES_CHKSUM = "file://COPYING.LIB;md5=4fbd65380cdd255951079008b364516c"
+
+SRC_URI = "https://gstreamer.freedesktop.org/src/${REALPN}/${REALPN}-${PV}.tar.xz"
+
+SRC_URI[sha256sum] = "2d643fbd1420297da5a4d6945d11f0a5b4f82feea54ea6aec9368d42995d8b03"
+
+S = "${WORKDIR}/${REALPN}-${PV}"
+DEPENDS = "libva gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-bad"
+
+inherit meson pkgconfig features_check upstream-version-is-even
+
+REQUIRED_DISTRO_FEATURES ?= "opengl"
+
+EXTRA_OEMESON += " \
+    -Ddoc=disabled \
+    -Dexamples=disabled \
+    -Dtests=enabled \
+"
+
+PACKAGES =+ "${PN}-tests"
+
+# OpenGL packageconfig factored out to make it easy for distros
+# and BSP layers to pick either glx, egl, or no GL. By default,
+# try detecting X11 first, and if found (with OpenGL), use GLX,
+# otherwise try to check if EGL can be used.
+PACKAGECONFIG_GL ?= "${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', 'glx', \
+                        bb.utils.contains('DISTRO_FEATURES',     'opengl', 'egl', \
+                                                                       '', d), d)}"
+
+PACKAGECONFIG ??= "drm encoders \
+                   ${PACKAGECONFIG_GL} \
+                   ${@bb.utils.filter('DISTRO_FEATURES', 'wayland x11', d)}"
+
+PACKAGECONFIG[drm] = "-Ddrm=enabled,-Ddrm=disabled,udev libdrm"
+PACKAGECONFIG[egl] = "-Degl=enabled,-Degl=disabled,virtual/egl"
+PACKAGECONFIG[encoders] = "-Dencoders=enabled,-Dencoders=disabled"
+PACKAGECONFIG[glx] = "-Dglx=enabled,-Dglx=disabled,virtual/libgl"
+PACKAGECONFIG[wayland] = "-Dwayland=enabled,-Dwayland=disabled,wayland-native wayland wayland-protocols"
+PACKAGECONFIG[x11] = "-Dx11=enabled,-Dx11=disabled,virtual/libx11 libxrandr libxrender"
+
+FILES:${PN} += "${libdir}/gstreamer-*/*.so"
+FILES:${PN}-dbg += "${libdir}/gstreamer-*/.debug"
+FILES:${PN}-dev += "${libdir}/gstreamer-*/*.a"
+FILES:${PN}-tests = "${bindir}/*"

--- a/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0/0001-tests-respect-the-idententaion-used-in-meson.patch
+++ b/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0/0001-tests-respect-the-idententaion-used-in-meson.patch
@@ -1,0 +1,33 @@
+From cb49c5433f343aa9ae6c0656d2e835365330922b Mon Sep 17 00:00:00 2001
+From: Jose Quaresma <quaresma.jose@gmail.com>
+Date: Sun, 11 Apr 2021 19:48:13 +0100
+Subject: [PATCH] tests: respect the idententaion used in meson
+
+Upstream-Status: Submitted [https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/789]
+
+Signed-off-by: Jose Quaresma <quaresma.jose@gmail.com>
+---
+ tests/check/meson.build | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/tests/check/meson.build b/tests/check/meson.build
+index e8419fc..4cc4618 100644
+--- a/tests/check/meson.build
++++ b/tests/check/meson.build
+@@ -149,11 +149,11 @@ foreach t : core_tests
+ 
+   if not skip_test
+     exe = executable(test_name, fname,
+-        c_args : gst_c_args + test_defines,
+-        cpp_args : gst_c_args + test_defines,
+-        include_directories : [configinc],
+-        link_with : link_with_libs,
+-        dependencies : gst_deps + test_deps,
++      c_args : gst_c_args + test_defines,
++      cpp_args : gst_c_args + test_defines,
++      include_directories : [configinc],
++      link_with : link_with_libs,
++      dependencies : gst_deps + test_deps,
+     )
+ 
+     env = environment()

--- a/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0/0002-tests-add-support-for-install-the-tests.patch
+++ b/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0/0002-tests-add-support-for-install-the-tests.patch
@@ -1,0 +1,106 @@
+From bfb530d2f0761f28c2645e2c45de5147b0528e4d Mon Sep 17 00:00:00 2001
+From: Jose Quaresma <quaresma.jose@gmail.com>
+Date: Sun, 11 Apr 2021 19:48:13 +0100
+Subject: [PATCH] tests: add support for install the tests
+
+This will provide to run the tests using the gnome-desktop-testing [1]
+
+[1] https://wiki.gnome.org/Initiatives/GnomeGoals/InstalledTests
+
+Upstream-Status: Submitted [https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/789]
+
+Signed-off-by: Jose Quaresma <quaresma.jose@gmail.com>
+---
+ meson.build                  |  4 ++++
+ meson_options.txt            |  1 +
+ tests/check/meson.build      | 22 +++++++++++++++++++++-
+ tests/check/template.test.in |  3 +++
+ 4 files changed, 29 insertions(+), 1 deletion(-)
+ create mode 100644 tests/check/template.test.in
+
+diff --git a/meson.build b/meson.build
+index ba50005..09c7212 100644
+--- a/meson.build
++++ b/meson.build
+@@ -664,6 +664,10 @@ if bashcomp_dep.found()
+   endif
+ endif
+ 
++installed_tests_enabled = get_option('installed_tests')
++installed_tests_metadir = join_paths(datadir, 'installed-tests', meson.project_name())
++installed_tests_execdir = join_paths(libexecdir, 'installed-tests', meson.project_name())
++
+ plugins_install_dir = join_paths(get_option('libdir'), 'gstreamer-1.0')
+ 
+ pkgconfig = import('pkgconfig')
+diff --git a/meson_options.txt b/meson_options.txt
+index 39255cf..78af552 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -16,6 +16,7 @@ option('poisoning', type : 'boolean', value : false, description : 'Enable poiso
+ option('memory-alignment', type: 'combo',
+        choices : ['1', '2', '4', '8', '16', '32', '64', '128', '256', '512', '1024', '2048', '4096', '8192', 'malloc', 'pagesize'],
+        value: 'malloc')
++option('installed_tests', type : 'boolean', value : false, description : 'Enable installed tests')
+ 
+ # Feature options
+ option('check', type : 'feature', value : 'auto', description : 'Build unit test libraries')
+diff --git a/tests/check/meson.build b/tests/check/meson.build
+index 4cc4618..f290e2e 100644
+--- a/tests/check/meson.build
++++ b/tests/check/meson.build
+@@ -128,10 +128,16 @@ test_defines = [
+   '-UG_DISABLE_ASSERT',
+   '-UG_DISABLE_CAST_CHECKS',
+   '-DGST_CHECK_TEST_ENVIRONMENT_BEACON="GST_STATE_IGNORE_ELEMENTS"',
+-  '-DTESTFILE="' + fsmod.as_posix(meson.current_source_dir()) + '/meson.build"',
+   '-DGST_DISABLE_DEPRECATED',
+ ]
+ 
++testfile = meson.current_source_dir() + '/meson.build'
++if installed_tests_enabled
++  install_data(testfile, install_dir : installed_tests_metadir, rename : 'testfile')
++  testfile = installed_tests_metadir + '/testfile'
++endif
++test_defines += '-DTESTFILE="@0@"'.format(testfile)
++
+ # sanity checking
+ if get_option('check').disabled()
+   if get_option('tests').enabled()
+@@ -154,6 +160,8 @@ foreach t : core_tests
+       include_directories : [configinc],
+       link_with : link_with_libs,
+       dependencies : gst_deps + test_deps,
++      install_dir: installed_tests_execdir,
++      install: installed_tests_enabled,
+     )
+ 
+     env = environment()
+@@ -165,6 +173,18 @@ foreach t : core_tests
+     env.set('GST_PLUGIN_SCANNER_1_0', gst_scanner_dir + '/gst-plugin-scanner')
+     env.set('GST_PLUGIN_LOADING_WHITELIST', 'gstreamer')
+ 
++    if installed_tests_enabled
++      test_conf = configuration_data()
++      test_conf.set('installed_tests_dir', join_paths(prefix, installed_tests_execdir))
++      test_conf.set('program', test_name)
++      configure_file(
++        input: 'template.test.in',
++        output: test_name + '.test',
++        install_dir: installed_tests_metadir,
++        configuration: test_conf
++      )
++    endif
++
+     test(test_name, exe, env: env, timeout : 3 * 60)
+   endif
+ endforeach
+diff --git a/tests/check/template.test.in b/tests/check/template.test.in
+new file mode 100644
+index 0000000..f701627
+--- /dev/null
++++ b/tests/check/template.test.in
+@@ -0,0 +1,3 @@
++[Test]
++Type=session
++Exec=@installed_tests_dir@/@program@

--- a/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0/0003-tests-use-a-dictionaries-for-environment.patch
+++ b/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0/0003-tests-use-a-dictionaries-for-environment.patch
@@ -1,0 +1,47 @@
+From d24110809da4588354ad3df4ae99556e8c62838a Mon Sep 17 00:00:00 2001
+From: Jose Quaresma <quaresma.jose@gmail.com>
+Date: Sat, 24 Apr 2021 10:34:47 +0100
+Subject: [PATCH] tests: use a dictionaries for environment
+
+meson environment() can't be passed to configure_file and it is needed for installed_tests,
+use a dictionary as this is simplest solution to install the environment.
+
+Upstream-Status: Submitted [https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/789]
+
+Signed-off-by: Jose Quaresma <quaresma.jose@gmail.com>
+---
+ tests/check/meson.build | 21 +++++++++++++--------
+ 1 file changed, 13 insertions(+), 8 deletions(-)
+
+diff --git a/tests/check/meson.build b/tests/check/meson.build
+index f290e2e..a3ffcb6 100644
+--- a/tests/check/meson.build
++++ b/tests/check/meson.build
+@@ -164,14 +164,19 @@ foreach t : core_tests
+       install: installed_tests_enabled,
+     )
+ 
+-    env = environment()
+-    env.set('GST_PLUGIN_PATH_1_0', meson.project_build_root())
+-    env.set('GST_PLUGIN_SYSTEM_PATH_1_0', '')
+-    env.set('GST_STATE_IGNORE_ELEMENTS', '')
+-    env.set('CK_DEFAULT_TIMEOUT', '20')
+-    env.set('GST_REGISTRY', '@0@/@1@.registry'.format(meson.current_build_dir(), test_name))
+-    env.set('GST_PLUGIN_SCANNER_1_0', gst_scanner_dir + '/gst-plugin-scanner')
+-    env.set('GST_PLUGIN_LOADING_WHITELIST', 'gstreamer')
++    # meson environment object can't be passed to configure_file and
++    # installed tests uses configure_file to install the environment.
++    # use a dictionary as this is the simplest solution
++    # to install the environment.
++    env = {
++      'GST_PLUGIN_PATH_1_0': meson.project_build_root(),
++      'GST_PLUGIN_SYSTEM_PATH_1_0': '',
++      'GST_STATE_IGNORE_ELEMENTS': '',
++      'CK_DEFAULT_TIMEOUT': '20',
++      'GST_REGISTRY': '@0@/@1@.registry'.format(meson.current_build_dir(), test_name),
++      'GST_PLUGIN_SCANNER_1_0': gst_scanner_dir + '/gst-plugin-scanner',
++      'GST_PLUGIN_LOADING_WHITELIST': 'gstreamer',
++    }
+ 
+     if installed_tests_enabled
+       test_conf = configuration_data()

--- a/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0/0004-tests-add-helper-script-to-run-the-installed_tests.patch
+++ b/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0/0004-tests-add-helper-script-to-run-the-installed_tests.patch
@@ -1,0 +1,71 @@
+From 3b9ae399b57cfb6e332fac6a90997a3abd33c819 Mon Sep 17 00:00:00 2001
+From: Jose Quaresma <quaresma.jose@gmail.com>
+Date: Sun, 2 May 2021 01:58:01 +0100
+Subject: [PATCH] tests: add helper script to run the installed_tests
+
+- this is a bash script that will run the installed_tests
+with some of the environment variables used in the meson
+testing framework.
+
+Upstream-Status: Submitted [https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/789]
+
+Signed-off-by: Jose Quaresma <quaresma.jose@gmail.com>
+---
+ tests/check/meson.build      | 17 +++++++++++++++++
+ tests/check/template.sh.in   |  9 +++++++++
+ tests/check/template.test.in |  2 +-
+ 3 files changed, 27 insertions(+), 1 deletion(-)
+ create mode 100755 tests/check/template.sh.in
+
+diff --git a/tests/check/meson.build b/tests/check/meson.build
+index a3ffcb6..b907dcf 100644
+--- a/tests/check/meson.build
++++ b/tests/check/meson.build
+@@ -188,6 +188,23 @@ foreach t : core_tests
+         install_dir: installed_tests_metadir,
+         configuration: test_conf
+       )
++
++      # All the tests will be deployed on the target machine and
++      # we use the home folder ~ for the registry which will then expand at runtime.
++      # Using the /tmp/gstreamer-1.0/@0@.registry can be problematic as it mostly
++      # is mounted using tmpfs and if the machine crash from some reason we can lost the registry
++      # that is useful for debug propose of the tests itself.
++      env += {'GST_REGISTRY': '~/.cache/gstreamer-1.0/@0@.registry'.format(test_name)}
++
++      # Set the full path for the test it self.
++      env += {'TEST': '@0@/@1@'.format(join_paths(prefix, installed_tests_execdir), test_name)}
++
++      configure_file(
++        input : 'template.sh.in',
++        output: test_name + '.sh',
++        install_dir: installed_tests_execdir,
++        configuration : env,
++      )
+     endif
+ 
+     test(test_name, exe, env: env, timeout : 3 * 60)
+diff --git a/tests/check/template.sh.in b/tests/check/template.sh.in
+new file mode 100755
+index 0000000..f1318fa
+--- /dev/null
++++ b/tests/check/template.sh.in
+@@ -0,0 +1,9 @@
++#!/bin/sh
++
++set -ax
++
++CK_DEFAULT_TIMEOUT="@CK_DEFAULT_TIMEOUT@"
++GST_PLUGIN_LOADING_WHITELIST="@GST_PLUGIN_LOADING_WHITELIST@"
++GST_REGISTRY=@GST_REGISTRY@
++GST_STATE_IGNORE_ELEMENTS="@GST_STATE_IGNORE_ELEMENTS@"
++exec @TEST@ "$@"
+diff --git a/tests/check/template.test.in b/tests/check/template.test.in
+index f701627..b74ef6a 100644
+--- a/tests/check/template.test.in
++++ b/tests/check/template.test.in
+@@ -1,3 +1,3 @@
+ [Test]
+ Type=session
+-Exec=@installed_tests_dir@/@program@
++Exec=@installed_tests_dir@/@program@.sh

--- a/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0/run-ptest
+++ b/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0/run-ptest
@@ -1,0 +1,26 @@
+#! /bin/sh
+
+# Multiply all timeouts by five so they're more likely to work
+# on a loaded system. The default timeout is 20s so this makes it
+# one minute.
+export CK_TIMEOUT_MULTIPLIER=5
+
+# Skip some tests that we know are problematic
+export GST_CHECKS_IGNORE=""
+
+# gstnetclientclock.c:test_functioning is very sensitive to load
+GST_CHECKS_IGNORE="$GST_CHECKS_IGNORE,test_functioning"
+
+# aggregator.c:test_infinite_seek_50_src_live is known to be flaky
+# https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/410
+GST_CHECKS_IGNORE="$GST_CHECKS_IGNORE,test_infinite_seek_50_src_live"
+
+# Known unreliable tests as per subprojects/gst-devtools/validate/launcher/testsuites/check.py:
+GST_CHECKS_IGNORE="$GST_CHECKS_IGNORE,parser_pull_short_read"
+
+# These tests are fragile
+# https://bugzilla.yoctoproject.org/show_bug.cgi?id=14884
+# https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/3524
+GST_CHECKS_IGNORE="$GST_CHECKS_IGNORE,parser_convert_duration,parser_pull_frame_growth,parser_reverse_playback"
+
+gnome-desktop-testing-runner --parallel=4 gstreamer "$@"

--- a/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0_1.26.3.bb
+++ b/meta-flex-staging/recipes-multimedia/gstreamer/gstreamer1.0_1.26.3.bb
@@ -1,0 +1,74 @@
+SUMMARY = "GStreamer 1.0 multimedia framework"
+DESCRIPTION = "GStreamer is a multimedia framework for encoding and decoding video and sound. \
+It supports a wide range of formats including mp3, ogg, avi, mpeg and quicktime."
+HOMEPAGE = "http://gstreamer.freedesktop.org/"
+BUGTRACKER = "https://bugzilla.gnome.org/enter_bug.cgi?product=Gstreamer"
+SECTION = "multimedia"
+LICENSE = "LGPL-2.1-or-later"
+
+DEPENDS = "glib-2.0 glib-2.0-native libxml2 bison-native flex-native"
+
+inherit meson pkgconfig gettext upstream-version-is-even gobject-introspection ptest-gnome
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=69333daa044cb77e486cc36129f7a770 \
+                    file://gst/gst.h;beginline=1;endline=21;md5=e059138481205ee2c6fc1c079c016d0d"
+
+S = "${WORKDIR}/gstreamer-${PV}"
+
+SRC_URI = "https://gstreamer.freedesktop.org/src/gstreamer/gstreamer-${PV}.tar.xz \
+           file://run-ptest \
+           file://0001-tests-respect-the-idententaion-used-in-meson.patch \
+           file://0002-tests-add-support-for-install-the-tests.patch \
+           file://0003-tests-use-a-dictionaries-for-environment.patch \
+           file://0004-tests-add-helper-script-to-run-the-installed_tests.patch \
+           "
+SRC_URI[sha256sum] = "dc661603221293dccc740862425eb54fbbed60fb29d08c801d440a6a3ff82680"
+
+PACKAGECONFIG ??= "${@bb.utils.contains('PTEST_ENABLED', '1', 'tests', '', d)} \
+                   check \
+                   debug \
+                   tools"
+
+PACKAGECONFIG[debug] = "-Dgst_debug=true,-Dgst_debug=false"
+PACKAGECONFIG[tracer-hooks] = "-Dtracer_hooks=true,-Dtracer_hooks=false"
+PACKAGECONFIG[coretracers] = "-Dcoretracers=enabled,-Dcoretracers=disabled"
+PACKAGECONFIG[check] = "-Dcheck=enabled,-Dcheck=disabled"
+PACKAGECONFIG[tests] = "-Dtests=enabled -Dinstalled_tests=true,-Dtests=disabled -Dinstalled_tests=false"
+PACKAGECONFIG[unwind] = "-Dlibunwind=enabled,-Dlibunwind=disabled,libunwind"
+PACKAGECONFIG[dw] = "-Dlibdw=enabled,-Dlibdw=disabled,elfutils"
+PACKAGECONFIG[bash-completion] = "-Dbash-completion=enabled,-Dbash-completion=disabled,bash-completion"
+PACKAGECONFIG[tools] = "-Dtools=enabled,-Dtools=disabled"
+PACKAGECONFIG[setcap] = "-Dptp-helper-permissions=capabilities,,libcap libcap-native"
+
+# TODO: put this in a gettext.bbclass patch
+def gettext_oemeson(d):
+    if d.getVar('USE_NLS') == 'no':
+        return '-Dnls=disabled'
+    # Remove the NLS bits if USE_NLS is no or INHIBIT_DEFAULT_DEPS is set
+    if d.getVar('INHIBIT_DEFAULT_DEPS') and not oe.utils.inherits(d, 'cross-canadian'):
+        return '-Dnls=disabled'
+    return '-Dnls=enabled'
+
+EXTRA_OEMESON += " \
+    -Ddoc=disabled \
+    -Dexamples=disabled \
+    -Ddbghelp=disabled \
+    ${@gettext_oemeson(d)} \
+"
+
+GIR_MESON_ENABLE_FLAG = "enabled"
+GIR_MESON_DISABLE_FLAG = "disabled"
+
+PACKAGES += "${PN}-bash-completion"
+
+# Add the core element plugins to the main package
+FILES:${PN} += "${libdir}/gstreamer-1.0/*.so"
+FILES:${PN}-dev += "${libdir}/gstreamer-1.0/*.a ${libdir}/gstreamer-1.0/include"
+FILES:${PN}-bash-completion += "${datadir}/bash-completion/completions/ ${datadir}/bash-completion/helpers/gst*"
+FILES:${PN}-dbg += "${datadir}/gdb ${datadir}/gstreamer-1.0/gdb"
+
+RDEPENDS:${PN}-ptest:append:libc-glibc = " glibc-gconv-iso8859-5"
+
+CVE_PRODUCT = "gstreamer"
+
+PTEST_BUILD_HOST_FILES = ""


### PR DESCRIPTION
Upgrade gstreamer and its plugins we use to v1.26.3. The recipes are taken from master branch of openembedded-core, commit SHA1 e861561b354309b68fdfc11acd880b4beb90032c

Meson recipe also needs to be upgraded as a dependency. This changeset breaks libsrvg build due to some Meson/Cargo version mismatch, but we don't need gtk/srvg/Gonme stuff in the image which is coming in as a dependency of gstreamer1.0-plugins-bad package. Remove the corresponding packageconfig to get rid of these unwanted additional components

JIRA-ID: SB-24675