### PR TITLE
setup-rocky: update to use with rhel

### DIFF
--- a/meta-flex-distro/conf/distro/innexis-linux.conf
+++ b/meta-flex-distro/conf/distro/innexis-linux.conf
@@ -63,7 +63,9 @@ PACKAGE_CLASSES ?= "package_ipk"
 SANITY_TESTED_DISTROS = "\
     ubuntu-22.04 \n\
     ubuntu-24.04 \n\
-    rocky*-8* \n \
+    rocky*-8* \n\
+    rocky*-9* \n\
+    rhel*-9* \n \
 "
 
 # Remove MACHINE from default volname

--- a/scripts/setup-rocky
+++ b/scripts/setup-rocky
@@ -37,14 +37,14 @@ if [ "$(id -u)" != "0" ]; then
     exec sudo "$0" "$@"
 fi
 
-if ! grep -Pq '^ID=(?:|")rocky(?:|")' /etc/os-release; then
-    echo "This script is for Rocky OS only, aborting"
-    exit 1
+if grep -Pq '^ID=(?:|")rocky(?:|")' /etc/os-release; then
+    echo "Enabling any required repos"
+    
+    if grep -Pq '^VERSION_ID=(?:|")8\.' /etc/os-release; then
+        # Enable repo required for rpcgen package
+        dnf config-manager --set-enabled powertools
+    fi
 fi
-
-echo "Enabling any required repos"
-# Enable repo required for rpcgen package
-dnf config-manager --set-enabled powertools
 
 echo "Installing packages required to build Innexis Linux"
 dnf install --assumeyes "$@" $packages || {


### PR DESCRIPTION
* Removed Rocky host check to run it on Rocky and RHEL
* powertools repo is added to dnf config-manager for Rocky 8.6 only
* added rocky9.* and rhel9.* as supported hosts.

JIRA-ID: SB-24768