### PR TITLE
innexis-linux.conf: changing builddir to topdir

### DIFF
--- a/meta-flex-distro/conf/distro/innexis-linux.conf
+++ b/meta-flex-distro/conf/distro/innexis-linux.conf
@@ -315,7 +315,7 @@ FORKED_REPOS ?= ""
 PUBLIC_REPOS ?= "meta-sokol-flex ${FORKED_REPOS}"
 
 # Define a location for placing external artifacts to be used by the build
-FLEX_EXTERNAL_ARTIFACTS ?= "${BUILDDIR}/flex-external-artifacts"
+FLEX_EXTERNAL_ARTIFACTS ?= "${TOPDIR}/flex-external-artifacts"
 ## }}}1
 ## Includes {{{1
 


### PR DESCRIPTION
The BUILDDIR variable is not available to recipes in Yocto 5.0.11 so changing it to TOPDIR for flex external artifacts.

JIRA-ID: SB-24780