### PR TITLE
innexis-linux: Update SDK_VERSION to fix basehash value changed issue.

### DIFF
--- a/meta-flex-distro/conf/distro/innexis-linux.conf
+++ b/meta-flex-distro/conf/distro/innexis-linux.conf
@@ -22,7 +22,7 @@ ARCHIVE_RELEASE_VERSION = "${DISTRO_VERSION}"
 # Version of the scripts artifact, including setup-flex
 SCRIPTS_VERSION ?= "0"
 
-SDK_VERSION = "${@d.getVar('DISTRO_VERSION').replace('+snapshot-${DATE}', '')}.${SDK_TIMESTAMP}"
+SDK_VERSION = "${DISTRO_VERSION}.${SDK_TIMESTAMP}"
 SDK_VERSION[vardepsexclude] += "SDK_TIMESTAMP"
 
 SDK_TIMESTAMP = "${@d.getVar('DATETIME')[:-2]}"


### PR DESCRIPTION
* While building sdk following error was coming ERROR: When reparsing /home/ashish/siemens/eda/install_23rd_sep/innexis-linux/2025.4/workspace/oe-core/meta/recipes-core/meta/meta-environment.bb:do_generate_content, the basehash value changed from c4a953973742e9c001e8e2cc942f085d569b58995db56f1f315e913df1d5d426 to 75ad5e9f8a1ab8efc9a57ec387655a686c380c08f147dd38be4b3519f10c8b34. The metadata is not deterministic and this needs to be fixed. ERROR: The following commands may help: ERROR: $ bitbake meta-environment-innexis-arm64 -cdo_generate_content -Snone ERROR: Then: ERROR: $ bitbake meta-environment-innexis-arm64 -cdo_generate_content -Sprintdiff

  This happend only when we first build  development image in brand new build folder. After a day (when date chnages) when sdk tis built hen above error shows up. The reason is we are using DATE variable in SDK_VERSION SDK_VERSION = "${@d.getVar('DISTRO_VERSION').replace('+snapshot-${DATE}', '')}.${SDK_TIMESTAMP}" As DATE changes so cache value changes and we get above error. As we are not using DATE in DISTRO_VERSION there is no need to replace it. So removed it from SDK_VERSION.
* JIRA: SB-24771