### PR TITLE
setup-rocky: remove tar from rocky setup script.

### DIFF
--- a/scripts/setup-rocky
+++ b/scripts/setup-rocky
@@ -11,7 +11,7 @@
 
 packages="python39 \
           python3-setuptools \
-          patch diffstat git bzip2 tar \
+          patch diffstat git bzip2 \
           gzip gawk chrpath wget cpio perl file which \
           rsync rpcgen \
           zstd lz4"


### PR DESCRIPTION
info: tar package was upgraded when setup script
        was ran which was causing build failure.