### PR TITLE
mesa: resolving fetch error with offline build

### DIFF
--- a/meta-flex-staging/recipes-graphics/mesa/mesa.inc
+++ b/meta-flex-staging/recipes-graphics/mesa/mesa.inc
@@ -24,7 +24,7 @@ SRC_URI = "git://gitlab.freedesktop.org/mesa/mesa.git;protocol=https;branch=25.2
            file://0001-vulkan_enc-meson.build-remove-TMPDIR-reference.patch \
 "
 
-SRCREV = "mesa-25.2.7"
+SRCREV = "461196a1c827769168304ff3f5b36360f16618ca"
 S = "${WORKDIR}/git"
 
 #because we cannot rely on the fact that all apps will use pkgconfig,


### PR DESCRIPTION
For an offline build(BB_NO_NETWORK=1) the exact src revision should be specified in the recipe. Updating mesa_git recipe.

JIRA-ID: SB-24906