### PR TITLE
weston-init.sh: export mesa_vk_wsi_debug

### DIFF
--- a/meta-flex-distro/recipes-graphics/wayland/weston-init/weston-init.sh
+++ b/meta-flex-distro/recipes-graphics/wayland/weston-init/weston-init.sh
@@ -1,1 +1,2 @@
 export WAYLAND_DISPLAY=/run/wayland-0
+export MESA_VK_WSI_DEBUG=sw,buffer


### PR DESCRIPTION
vkmark reports an error on jasper-lite:
*ERROR* response 0x1200
Need to export MESA_VK_WSI_DEBUG=sw,buffer

JIRA-ID: SB-24949