### PR TITLE
meta-flex-staging: Fix remaining WORKDIR references

### DIFF
--- a/meta-flex-staging/dynamic-layers/openembedded-layer/recipes-extended/libmodbus/libmodbus_%.bbappend
+++ b/meta-flex-staging/dynamic-layers/openembedded-layer/recipes-extended/libmodbus/libmodbus_%.bbappend
@@ -12,6 +12,6 @@ inherit ptest
 
 do_install_ptest:feature-flex-staging() {
         install -d ${D}${PTEST_PATH}/tests/
-        install -m 0755 ${WORKDIR}/*-test ${B}/tests/.libs/* ${D}${PTEST_PATH}/tests/
+        install -m 0755 ${UNPACKDIR}/*-test ${B}/tests/.libs/* ${D}${PTEST_PATH}/tests/
         sed -i -e 's#@PTEST_PATH@#${PTEST_PATH}#g' ${D}${PTEST_PATH}/run-ptest
 }

--- a/meta-flex-staging/security/recipes-ids/tripwire/tripwire_%.bbappend
+++ b/meta-flex-staging/security/recipes-ids/tripwire/tripwire_%.bbappend
@@ -20,5 +20,5 @@ do_install:append:feature-flex-staging () {
         rm -f "${D}${sysconfdir}/tripwire/twinstall.sh"
     fi
     install -d "${D}${bindir}"
-    install -m 0755 "${WORKDIR}/twinstall.sh" "${D}${bindir}/"
+    install -m 0755 "${UNPACKDIR}/twinstall.sh" "${D}${bindir}/"
 }


### PR DESCRIPTION
The migration only moved file:// SRC_URI entries from WORKDIR to UNPACKDIR, so the instances that are still left are legitimate WORKDIR usage