### PR TITLE
setup-rocky: include tar in rocky setup script.

### DIFF
--- a/scripts/setup-rocky
+++ b/scripts/setup-rocky
@@ -11,7 +11,7 @@
 
 packages="python39 \
           python3-setuptools \
-          patch diffstat git bzip2 \
+          patch diffstat git bzip2 tar \
           gzip gawk chrpath wget cpio perl file which \
           rsync rpcgen \
           zstd lz4"


### PR DESCRIPTION
include tar to updgrade tar version to fix build error 
----------------------
Your version of tar is older than 1.35 and crashes when extracting read-only files with xattrs. Your distro is rocky-9.4 which triggers this bug due to the presence of selinux attributes. Please install a newer version of tar (you could use the project's buildtools-tarball from our last release or use scripts/install-buildtools).
----------------------